### PR TITLE
Re-creating the flex grid from quark-ui

### DIFF
--- a/src/core/grid/exampleFlexRow.js
+++ b/src/core/grid/exampleFlexRow.js
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { FlexRow } from 'SRC'
+
+const ExampleFlexRow = styled.section`
+  ${FlexRow}
+  background-color: #CCCCCC;
+  div {
+    margin-top: 1rem;
+    > span {
+      background-color: #F3F3F3;
+      height: 8rem;
+      display: block;
+      width: 100%;
+    }
+  }
+`
+
+ExampleFlexRow.propTypes = {
+  constrained: PropTypes.bool,
+  padding: PropTypes.bool
+}
+
+ExampleFlexRow.defaultProps = {
+  constrained: true,
+  padding: true
+}
+
+/** @component */
+export default ExampleFlexRow

--- a/src/core/grid/exampleFlexRow.md
+++ b/src/core/grid/exampleFlexRow.md
@@ -1,0 +1,38 @@
+```js
+/**
+ * ExampleFlexRow imports FlexRow styles simply by doing the following:
+ * const ExampleFlexRow = styled.section`
+ *  ${FlexRow}
+ * `
+**/
+  <ExampleFlexRow>
+    <FlexCol><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 6}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 6}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 4}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 4}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 4}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 3}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 3}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 3}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 3}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 2}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 2}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 2}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 2}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 2}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 2}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 1}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 1}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 1}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 1}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 1}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 1}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 1}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 1}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 1}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 1}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 1}}><div><span/></div></FlexCol>
+    <FlexCol desktop={{width: 1}}><div><span/></div></FlexCol>
+  </ExampleFlexRow>
+```

--- a/src/core/grid/flexCol.js
+++ b/src/core/grid/flexCol.js
@@ -1,0 +1,82 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled, {css} from 'styled-components'
+
+const columnToPercent = (elementWidth, containerWidth) => {
+  return `${100 * (elementWidth/containerWidth)}%`
+}
+
+const spanner = (props, breakpoint) => {
+  console.log(props)
+  if (props[breakpoint].span) {
+    return css`
+      margin-left: ${props => props.desktop.nested
+        ? columnToPercent(props.desktop.span, props.desktop.nested)
+        : columnToPercent(props.desktop.span, props.theme.grid.columns.desktop)};
+    `
+  } else {
+    return null
+  }
+}
+
+const FlexCol = styled(({ className, children, ...props}) => {
+  return React.cloneElement(children, {
+    className: `${children.props.className ? `${children.props.className} ` : ``}${className}`
+  })
+})`
+  box-sizing: border-box;
+  max-width: ${props => props.mobile.nested
+    ? columnToPercent(props.mobile.width, props.mobile.nested)
+    : columnToPercent(props.mobile.width, props.theme.grid.columns.mobile)};
+  flex-basis: ${props => props.mobile.nested
+    ? columnToPercent(props.mobile.width, props.mobile.nested)
+    : columnToPercent(props.mobile.width, props.theme.grid.columns.mobile)};
+  ${props => spanner(props, 'mobile')}
+  ${props => props.nested
+    ? `
+      padding-left: 0;
+      padding-right: 0;
+    `
+    : `
+      padding-left: 5px;
+      padding-right: 5px;
+    `
+  }
+
+  ${props => props.theme.media.tablet`
+    max-width: ${props => props.desktop.nested
+      ? columnToPercent(props.desktop.width, props.desktop.nested)
+      : columnToPercent(props.desktop.width, props.theme.grid.columns.desktop)};
+    flex-basis: ${props => props.desktop.nested
+      ? columnToPercent(props.desktop.width, props.desktop.nested)
+      : columnToPercent(props.desktop.width, props.theme.grid.columns.desktop)};
+    ${ props => spanner(props, 'desktop')}
+  `
+}
+`
+
+FlexCol.propTypes = {
+  children: PropTypes.node.isRequired,
+  mobile: PropTypes.shape({
+    width: PropTypes.number.isRequired,
+    span: PropTypes.number,
+    nested: PropTypes.number
+  }),
+  desktop: PropTypes.shape({
+    width: PropTypes.number.isRequired,
+    span: PropTypes.number,
+    nested: PropTypes.number
+  }),
+}
+
+FlexCol.defaultProps = {
+  mobile: {
+    width: 4
+  },
+  desktop: {
+    width: 12
+  }
+}
+
+/** @component */
+export default FlexCol

--- a/src/core/grid/flexRow.base.js
+++ b/src/core/grid/flexRow.base.js
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types'
+import { css } from 'styled-components'
+
+const constrained = css`
+  max-width: 1440px;
+  margin: 0 auto;
+`
+
+const notConstrained = css`
+  max-width: 100%;
+  margin-left: 10px;
+  margin-right: 10px;
+  ${props => props.theme.media.tablet`
+    margin-left: 20px;
+    margin-right: 20px;
+  `}
+`
+
+const padding = css`
+  padding: 0 3%;
+  ${props => props.theme.media.tablet`
+    padding: 0 7%;
+  `}
+`
+
+const FlexRow = css`
+  display: flex;
+  flex-wrap: wrap;
+  ${props => props.constrained ? constrained : notConstrained}
+  ${props => props.padding && padding}
+`
+
+FlexRow.propTypes = {
+  constrained: PropTypes.bool,
+  padding: PropTypes.bool
+}
+
+/** @component */
+export default FlexRow

--- a/src/core/grid/index.js
+++ b/src/core/grid/index.js
@@ -1,2 +1,4 @@
 export {default as Grid} from './grid'
 export {default as Sizer} from './sizer'
+export {default as FlexRow} from './flexRow.base'
+export {default as FlexCol} from './flexCol'


### PR DESCRIPTION
This PR adds the existing functionality that we have developed on
quark-ui in styled component form!

For the `FlexRow`, simply importing the `FlexRow` css into your component
and it will automatically have styling applied the the element.
Adding override props to the component that implements `FlexRow` will
pass those down to the `FlexRow` styling. My hope is at some point in the
near future to automatically detect if a `FlexRow` is nested via context
so that we won't have to worry about the nested prop.

For the `FlexCol` things get a little more complex as we have to be able
to pass specific props to it. In order to keep a cleaner DOM structure,
the `FlexCol` component actually clones it's child element and applies
the sizing styles to the child and returns it. This allows for the
flexibility to pass sizing props to an actual component without having as
much HTML markup.

An Example can be found in the `ExampleFlexRow` component