### PR TITLE
Making BackgroundVideo responsive

### DIFF
--- a/src/components/customerQuotes/__snapshots__/customerQuotes.test.js.snap
+++ b/src/components/customerQuotes/__snapshots__/customerQuotes.test.js.snap
@@ -12,6 +12,8 @@ exports[`(Styled Component) CustomerQuotes matching the snapshot 1`] = `
   max-width: 1440px;
   margin: 0 auto;
   padding: 0 3%;
+  margin-top: 4rem;
+  margin-bottom: 2rem;
 }
 
 .c0 .c1,
@@ -36,11 +38,18 @@ exports[`(Styled Component) CustomerQuotes matching the snapshot 1`] = `
   height: 100%;
   margin-top: 0;
   margin-bottom: 0;
+  min-height: 20rem;
 }
 
 @media (min-width:76.8em) {
   .c0 {
     padding: 0 7%;
+  }
+}
+
+@media (min-width:76.8em) {
+  .c0 {
+    margin-top: 6rem;
   }
 }
 

--- a/src/components/video/__snapshots__/backgroundVideo.test.js.snap
+++ b/src/components/video/__snapshots__/backgroundVideo.test.js.snap
@@ -18,21 +18,47 @@ exports[`(Styled Component) BackgroundVideo matching the snapshot 1`] = `
 }
 
 <Styled(BaseBackgroundVideo)
-  sources="www.example.com/example.mp4"
+  size={
+    Object {
+      "width": 300,
+    }
+  }
+  sources={
+    Object {
+      "0": "https://videos.ctfassets.net/8hhsfnb6grdi/7Iiffn2YxDIeMNqnG80As5/01aa536f3cd8ce2daa6d33b9b9c21543/ROA_Test01_Mobile.mp4",
+      "768": "https://videos.ctfassets.net/8hhsfnb6grdi/4vn6I5vreD5xJGa24tBcLX/f9fa268493031b19e2610b4b4a66381d/ROA_Test01_1.mp4",
+    }
+  }
 >
   <BaseBackgroundVideo
     className="c0"
-    sources="www.example.com/example.mp4"
+    size={
+      Object {
+        "width": 300,
+      }
+    }
+    sources={
+      Object {
+        "0": "https://videos.ctfassets.net/8hhsfnb6grdi/7Iiffn2YxDIeMNqnG80As5/01aa536f3cd8ce2daa6d33b9b9c21543/ROA_Test01_Mobile.mp4",
+        "768": "https://videos.ctfassets.net/8hhsfnb6grdi/4vn6I5vreD5xJGa24tBcLX/f9fa268493031b19e2610b4b4a66381d/ROA_Test01_1.mp4",
+      }
+    }
   >
     <section
       className="c0"
+      sources={
+        Object {
+          "0": "https://videos.ctfassets.net/8hhsfnb6grdi/7Iiffn2YxDIeMNqnG80As5/01aa536f3cd8ce2daa6d33b9b9c21543/ROA_Test01_Mobile.mp4",
+          "768": "https://videos.ctfassets.net/8hhsfnb6grdi/4vn6I5vreD5xJGa24tBcLX/f9fa268493031b19e2610b4b4a66381d/ROA_Test01_1.mp4",
+        }
+      }
     >
       <Video
         autoPlay={true}
         loop={true}
         muted={true}
         playsInline={true}
-        sources="www.example.com/example.mp4"
+        sources="https://videos.ctfassets.net/8hhsfnb6grdi/7Iiffn2YxDIeMNqnG80As5/01aa536f3cd8ce2daa6d33b9b9c21543/ROA_Test01_Mobile.mp4"
       >
         <video
           autoPlay={true}
@@ -42,7 +68,7 @@ exports[`(Styled Component) BackgroundVideo matching the snapshot 1`] = `
         >
           <source
             key="0"
-            src="www.example.com/example.mp4"
+            src="https://videos.ctfassets.net/8hhsfnb6grdi/7Iiffn2YxDIeMNqnG80As5/01aa536f3cd8ce2daa6d33b9b9c21543/ROA_Test01_Mobile.mp4"
             type="video/mp4"
           />
         </video>

--- a/src/components/video/backgroundVideo.js
+++ b/src/components/video/backgroundVideo.js
@@ -2,14 +2,61 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Video } from 'SRC/core/video'
+import { withSize } from 'react-sizeme'
 
-const BaseBackgroundVideo = ({className, children, sources, ...props}) => {
-  return (
-    <section className={className} {...props}>
-      <Video sources={sources} />
-      <article>{children}</article>
-    </section>
-  )
+class BaseBackgroundVideo extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      currentSources: undefined
+    }
+    this.backgroundVideo = null
+  }
+
+  setResponsiveBackground = () => {
+    const { size: { width }, sources } = this.props
+    const { currentSources } = this.state
+    if (sources) {
+      const newSources = sources[Object.keys(sources)
+      .sort((keyA, keyB) => keyA-keyB)
+      .reverse()
+      .find((key) => {
+        return(key < width)
+      })]
+      if(currentSources !== newSources) {
+        this.setState({
+          currentSources: newSources
+        })
+        if (this.backgroundVideo && this.backgroundVideo.video) {
+          this.backgroundVideo.video.load()
+          this.backgroundVideo.video.play()
+        }
+      }
+    }
+  }
+
+  setVideo = (element) => {
+    this.backgroundVideo = element
+  }
+
+  componentDidMount () {
+    this.setResponsiveBackground()
+  }
+
+  componentDidUpdate() {
+    this.setResponsiveBackground()
+  }
+
+  render () {
+    const {className, children, size, ...props} = this.props
+    const { currentSources } = this.state
+    return (
+      <section className={className} {...props}>
+        <Video ref={this.setVideo} sources={currentSources} />
+        <article>{children}</article>
+      </section>
+    )
+  }
 }
 
 const BackgroundVideo = styled(BaseBackgroundVideo)`
@@ -27,11 +74,10 @@ const BackgroundVideo = styled(BaseBackgroundVideo)`
 `
 
 BackgroundVideo.propTypes = {
-  sources: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.string
-  ])
+  sources: PropTypes.object
 }
 
+export { BackgroundVideo }
+
 /** @component */
-export default BackgroundVideo
+export default withSize()(BackgroundVideo)

--- a/src/components/video/backgroundVideo.md
+++ b/src/components/video/backgroundVideo.md
@@ -1,5 +1,10 @@
 ```js
-  <BackgroundVideo sources='http://videos.ctfassets.net/8viklopqoo0g/54jDRvPlGEUkmAAAsSMIKY/a2b74a7e9abb1d43fe235a351c376158/Bokeh_Video_Of_Leaves.mp4'>
+  <BackgroundVideo sources={
+    {
+      0: 'https://videos.ctfassets.net/8hhsfnb6grdi/7Iiffn2YxDIeMNqnG80As5/01aa536f3cd8ce2daa6d33b9b9c21543/ROA_Test01_Mobile.mp4',
+      768: 'https://videos.ctfassets.net/8hhsfnb6grdi/4vn6I5vreD5xJGa24tBcLX/f9fa268493031b19e2610b4b4a66381d/ROA_Test01_1.mp4'
+    }
+  }>
     <Grid style={{height: '100%'}}>
       <Sizer style={{alignSelf: 'center'}}desktop={{start: 3, width: 8}}>
         <H1 style={{textAlign: 'center'}}>Summer Breeze</H1>

--- a/src/components/video/backgroundVideo.test.js
+++ b/src/components/video/backgroundVideo.test.js
@@ -2,13 +2,19 @@ import React from 'react'
 import { css } from 'styled-components'
 import 'jest-styled-components'
 
-import { BackgroundVideo } from 'SRC'
+import { BackgroundVideo } from './backgroundVideo'
 
 const { mountWithTheme } = global
 
 describe('(Styled Component) BackgroundVideo', () => {
   const defaultProps = {
-    sources: 'www.example.com/example.mp4',
+    sources: {
+      0: 'https://videos.ctfassets.net/8hhsfnb6grdi/7Iiffn2YxDIeMNqnG80As5/01aa536f3cd8ce2daa6d33b9b9c21543/ROA_Test01_Mobile.mp4',
+      768: 'https://videos.ctfassets.net/8hhsfnb6grdi/4vn6I5vreD5xJGa24tBcLX/f9fa268493031b19e2610b4b4a66381d/ROA_Test01_1.mp4'
+    },
+    size: {
+      width: 300
+    },
     children: <h1>Hello</h1>
   }
   const createBackgroundVideo = (props = defaultProps) => {
@@ -25,10 +31,11 @@ describe('(Styled Component) BackgroundVideo', () => {
       createBackgroundVideo()
       .find('Video')
       .prop('sources')
-    ).toEqual(defaultProps.sources)
+    ).toEqual(defaultProps.sources[0])
   })
 
   test('passing children into article', () => {
+    console.log(createBackgroundVideo().debug())
     expect(
       createBackgroundVideo()
       .find('article')

--- a/src/core/video/video.js
+++ b/src/core/video/video.js
@@ -2,19 +2,31 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Source from './sources.base'
 
-const Video = ({children, sources: inSources, ...props}) => {
-  let sources = []
-  if (inSources) {
-    sources = new Source(inSources).render()
+class Video extends React.Component {
+  constructor (props) {
+    super(props)
+    this.video = null
   }
-  return (
-    <video {...props}>
-      {sources.map((source, key) => {
-        return source
-      })}
-      {children && children}
-    </video>
-  )
+
+  setVideoRef = (element) => {
+    this.video = element
+  }
+
+  render () {
+    const {children, sources: inSources, ...props} = this.props
+    let sources = []
+    if (inSources) {
+      sources = new Source(inSources).render()
+    }
+    return (
+      <video ref={this.setVideoRef} {...props}>
+        {sources.map((source, key) => {
+          return source
+        })}
+        {children && children}
+      </video>
+    )
+  }
 }
 
 Video.propTypes = {


### PR DESCRIPTION
Due to an issue where our content was taller than our background video
we had some issues where the children of the tout were overflowing in
the Tout. This PR allows us to have two video files that are pulled in
when a specific breakpoint is reached. This paradigm is similar to how
we do backgroundImages in Mirage.

![responsive_backgroundvideo](https://user-images.githubusercontent.com/1794777/51938742-de8b6c80-23db-11e9-937d-d7ba0a52197f.gif)