### PR TITLE
Fixes centering for press quotes styling

### DIFF
--- a/src/components/pressQuotes/pressQuotes.js
+++ b/src/components/pressQuotes/pressQuotes.js
@@ -120,13 +120,15 @@ class BasePressQuotes extends React.Component {
             <Chevron right onClick={this.onClickChevronRight} />
           </div>
         </FlexCol>
-        <MediaQuery query={theme.breakpoints.aboveTabletMax}>
-          {this.renderPressRow(topRow)}
-          {this.renderPressRow(bottomRow)}
-        </MediaQuery>
-        <MediaQuery query="(max-device-width: 959px)">
-          {this.renderPressRowMobile()}
-        </MediaQuery>
+        <FlexCol mobile={{width: 4}} desktop={{span: 1, width: 10}}>
+          <MediaQuery query={theme.breakpoints.aboveTabletMax}>
+            {this.renderPressRow(topRow)}
+            {this.renderPressRow(bottomRow)}
+          </MediaQuery>
+          <MediaQuery query="(max-device-width: 959px)">
+            {this.renderPressRowMobile()}
+          </MediaQuery>
+        </FlexCol>
       </section>
     )
   }


### PR DESCRIPTION
#### What does this PR do?
On really wide displays the centering was off for press quotes; this fixes that.

#### Screenshots
<img width="1028" alt="screen shot 2019-02-04 at 6 05 43 pm" src="https://user-images.githubusercontent.com/723087/52243452-abe3e700-28a7-11e9-8314-6379a3cbad9e.png">
