### PR TITLE
Customer quotes w/ name, location & styling updates

### DIFF
--- a/src/components/customerQuotes/__snapshots__/customerQuotes.test.js.snap
+++ b/src/components/customerQuotes/__snapshots__/customerQuotes.test.js.snap
@@ -21,11 +21,13 @@ exports[`(Styled Component) CustomerQuotes matching the snapshot 1`] = `
 }
 
 .c0 .c1,
-.c0 .c2 {
+.c0 .c2,
+.c0 .c3 {
   text-align: center;
 }
 
-.c0 .c2 {
+.c0 .c2,
+.c0 .c3 {
   color: #0073D1;
   display: -webkit-box;
   display: -webkit-flex;
@@ -42,8 +44,39 @@ exports[`(Styled Component) CustomerQuotes matching the snapshot 1`] = `
   height: 100%;
   margin-top: 0;
   margin-bottom: 0;
-  min-height: 20rem;
   font-style: italic;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c0 .c2 {
+  margin-top: 1rem;
+  min-height: 5rem;
+}
+
+.c0 .c3 {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  min-height: 1rem;
+}
+
+.c0 .quote_controller {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
@@ -78,7 +111,16 @@ exports[`(Styled Component) CustomerQuotes matching the snapshot 1`] = `
 }
 
 @media (min-width:76.8em) {
-  .c0 .c2 {
+  .c0 .c2,
+  .c0 .c3 {
+    -webkit-order: 2;
+    -ms-flex-order: 2;
+    order: 2;
+  }
+}
+
+@media (min-width:76.8em) {
+  .c0 .quote_controller {
     -webkit-order: 2;
     -ms-flex-order: 2;
     order: 2;

--- a/src/components/customerQuotes/__snapshots__/customerQuotes.test.js.snap
+++ b/src/components/customerQuotes/__snapshots__/customerQuotes.test.js.snap
@@ -43,6 +43,7 @@ exports[`(Styled Component) CustomerQuotes matching the snapshot 1`] = `
   margin-top: 0;
   margin-bottom: 0;
   min-height: 20rem;
+  font-style: italic;
   -webkit-order: 1;
   -ms-flex-order: 1;
   order: 1;
@@ -99,10 +100,22 @@ exports[`(Styled Component) CustomerQuotes matching the snapshot 1`] = `
   padding={true}
   quotes={
     Array [
-      "“These are real clothes to LIVE and PLAY in! My son is full of personality and wears Rockets of Awesome to reflect that.”—Andrea",
-      "“My spunky daughter loves to be an original and love that we've found a brand that can help her define her unique sense of self!”—Maddie",
-      "“My son loves your stuff more than any of his other clothes, and digs through his drawers to find them! I’m not sure if it’s the super-softness or the graphics, but thank you!”—Courtney",
-      "“It’s great to see my kids feel so confident that what they’re wearing expresses who they are as individuals.”—Robin",
+      Object {
+        "quote": "“These are real clothes to LIVE and PLAY in! My son is full of personality and wears Rockets of Awesome to reflect that.”",
+        "signature": "— Andrea, Dallas TX",
+      },
+      Object {
+        "quote": "“My spunky daughter loves to be an original and love that we've found a brand that can help her define her unique sense of self!”",
+        "signature": "— Maddie, Cincinnati OH",
+      },
+      Object {
+        "quote": "“My son loves your stuff more than any of his other clothes, and digs through his drawers to find them! I’m not sure if it’s the super-softness or the graphics, but thank you!”",
+        "signature": "— Courtney, Philadelphia PA",
+      },
+      Object {
+        "quote": "“It’s great to see my kids feel so confident that what they’re wearing expresses who they are as individuals.”",
+        "signature": "— Robin, Brooklyn NY",
+      },
     ]
   }
 />

--- a/src/components/customerQuotes/customerQuotes.js
+++ b/src/components/customerQuotes/customerQuotes.js
@@ -7,7 +7,7 @@ import {
   FlexRow,
   InlineImage,
   H1,
-  H3
+  H2
 } from 'SRC'
 
 import defaultProps from './defaultProps.js'
@@ -18,7 +18,7 @@ class BaseCustomerQuotes extends React.Component {
     super(props)
     this.state = {
       index: 0,
-      quote: undefined
+      quote: { quote: undefined, signature: undefined }
     }
   }
 
@@ -45,7 +45,7 @@ class BaseCustomerQuotes extends React.Component {
         </FlexCol>
         <FlexCol mobile={{width: 4}} desktop={{width: 6}}>
           <FadeInOut duration={9} animate={!!index}>
-            <H3 lowercase>{quote}</H3>
+            <H2 lowercase>{quote.quote}<br />{quote.signature}</H2>
           </FadeInOut>
         </FlexCol>
         <FlexCol mobile={{width: 2}} desktop={{width: 3}}>
@@ -82,10 +82,10 @@ const CustomerQuotes = styled(BaseCustomerQuotes)`
   ${props => props.theme.media.tablet`
     margin-top: 6rem;
   `}
-  ${H1}, ${H3} {
+  ${H1}, ${H2} {
     text-align: center;
   }
-  ${H3} {
+  ${H2} {
     color: ${props => props.theme.colors.rocketBlue};
     display: flex;
     justify-content: center;
@@ -94,6 +94,7 @@ const CustomerQuotes = styled(BaseCustomerQuotes)`
     margin-top: 0;
     margin-bottom: 0;
     min-height: 20rem;
+    font-style: italic;
     order: 1;
     ${props => props.theme.media.tablet`
       order: 2;

--- a/src/components/customerQuotes/customerQuotes.js
+++ b/src/components/customerQuotes/customerQuotes.js
@@ -7,7 +7,8 @@ import {
   FlexRow,
   InlineImage,
   H1,
-  H2
+  H2,
+  H3
 } from 'SRC'
 
 import defaultProps from './defaultProps.js'
@@ -45,7 +46,10 @@ class BaseCustomerQuotes extends React.Component {
         </FlexCol>
         <FlexCol mobile={{width: 4}} desktop={{width: 6}}>
           <FadeInOut duration={9} animate={!!index}>
-            <H2 lowercase>{quote.quote}<br />{quote.signature}</H2>
+            <div className="quote_controller">
+              <H2 lowercase>{quote.quote}</H2>
+              <H3 lowercase>{quote.signature}</H3>
+            </div>
           </FadeInOut>
         </FlexCol>
         <FlexCol mobile={{width: 2}} desktop={{width: 3}}>
@@ -82,10 +86,10 @@ const CustomerQuotes = styled(BaseCustomerQuotes)`
   ${props => props.theme.media.tablet`
     margin-top: 6rem;
   `}
-  ${H1}, ${H2} {
+  ${H1}, ${H2}, ${H3} {
     text-align: center;
   }
-  ${H2} {
+  ${H2}, ${H3} {
     color: ${props => props.theme.colors.rocketBlue};
     display: flex;
     justify-content: center;
@@ -93,14 +97,31 @@ const CustomerQuotes = styled(BaseCustomerQuotes)`
     height: 100%;
     margin-top: 0;
     margin-bottom: 0;
-    min-height: 20rem;
     font-style: italic;
     order: 1;
     ${props => props.theme.media.tablet`
       order: 2;
     `}
   }
-
+  ${H2} {
+    margin-top: 1rem;
+    min-height: 5rem;
+  }
+  ${H3} {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+    min-height: 1rem;
+  }
+  .quote_controller {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    order: 1;
+    ${props => props.theme.media.tablet`
+      order: 2;
+    `}
+  }
   .confetti {
     height: auto;
     &:first-of-type {

--- a/src/components/customerQuotes/defaultProps.js
+++ b/src/components/customerQuotes/defaultProps.js
@@ -1,9 +1,21 @@
 export default {
   "header": "WHAT AWESOME PARENTS (LIKE YOU!) ARE SAYING",
   "quotes": [
-    "“These are real clothes to LIVE and PLAY in! My son is full of personality and wears Rockets of Awesome to reflect that.”—Andrea",
-    "“My spunky daughter loves to be an original and love that we've found a brand that can help her define her unique sense of self!”—Maddie",
-    "“My son loves your stuff more than any of his other clothes, and digs through his drawers to find them! I’m not sure if it’s the super-softness or the graphics, but thank you!”—Courtney",
-    "“It’s great to see my kids feel so confident that what they’re wearing expresses who they are as individuals.”—Robin"
+    {
+      quote: "“These are real clothes to LIVE and PLAY in! My son is full of personality and wears Rockets of Awesome to reflect that.”",
+      signature: "— Andrea, Dallas TX"
+    },
+    {
+      quote: "“My spunky daughter loves to be an original and love that we've found a brand that can help her define her unique sense of self!”",
+      signature: "— Maddie, Cincinnati OH"
+    },
+    {
+      quote: "“My son loves your stuff more than any of his other clothes, and digs through his drawers to find them! I’m not sure if it’s the super-softness or the graphics, but thank you!”",
+      signature: "— Courtney, Philadelphia PA"
+    },
+    {
+      quote: "“It’s great to see my kids feel so confident that what they’re wearing expresses who they are as individuals.”",
+      signature: "— Robin, Brooklyn NY"
+    }
   ]
 }


### PR DESCRIPTION
#### What does this PR do?
Updates the `CustomerQuotes` component: adding in a signature that has the quotee & location, updated styling to match `PressQuotes` and adjusted padding/margins to work well with new styling.

#### Screenshots
<img width="1211" alt="screen shot 2019-02-05 at 11 48 32 am" src="https://user-images.githubusercontent.com/723087/52289556-455cd880-293c-11e9-9921-72b637625da8.png">
