### PR TITLE
Adding Instagram caption to link

### DIFF
--- a/src/components/social-media/instagram.js
+++ b/src/components/social-media/instagram.js
@@ -42,6 +42,7 @@ class BaseInstagram extends React.Component {
       accessToken: accessToken,
       resolution: 'standard_resolution',
       limit: limit,
+      template: '<a class="image-link" aria-label="{{caption}}" href="{{link}}"><img src="{{image}}" aria-hidden /></a>',
       success: (args) => this.setInstragramPics(args)
     }).run()
     }
@@ -81,7 +82,7 @@ class BaseInstagram extends React.Component {
               })}
             </Slider>}
             <InlineImage className='mobileGif' src='https://res.cloudinary.com/roa-canon/image/upload/v1548777765/web/PHONE_ANIM.gif' />
-            <div ref={this.setInstagramRef} style={{display: 'none'}} />
+            <div ref={this.setInstagramRef} style={{display: 'none'}} aria-hidden />
           </div>
         </MediaQuery>
       </div>
@@ -138,6 +139,9 @@ const Instagram = styled(BaseInstagram)`
       justify-content: center;
       padding-right: 20px;
     }
+  }
+  .image-link {
+    font-size: 0px;
   }
 `
 

--- a/src/modules/social-media/__snapshots__/instagramRegion.test.js.snap
+++ b/src/modules/social-media/__snapshots__/instagramRegion.test.js.snap
@@ -117,6 +117,10 @@ exports[`(Styled Component) InstagramRegion matching the snapshot 1`] = `
   padding-right: 20px;
 }
 
+.c5 .image-link {
+  font-size: 0px;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;


### PR DESCRIPTION
Currently when a screen reader hits the instafeed images, it spouts off
the link to the instagram photo (which is a huge string of random
characters) what we are doing now is adding the instagram caption as an
aria-label to the link that wraps the image so screen readers will now
have some context around the image.