### PR TITLE
Touching up some issues on the PressQuotes section

### DIFF
--- a/src/components/pressQuotes/IconRow.js
+++ b/src/components/pressQuotes/IconRow.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+import PressIcon from 'SRC/core/icons/press/PressIcon'
+
+const IconRow = styled(({className, onClick, quotes, selected}) => {
+  return (
+    <div className={className}>
+      {quotes.map((icon, index) => {
+        const iconSelected = (index === selected)
+        return (
+          <PressIcon
+            key={index}
+            brand={quotes[index].id}
+            onClick={onClick(index)}
+            selected={iconSelected} />
+          )
+      })}
+    </div>
+  )
+})`
+  display: flex;
+  flex-wrap: wrap;
+  ${PressIcon} {
+    width: 25%;
+  }
+`
+
+IconRow.propTypes = {
+  iconsPerRow: PropTypes.number
+}
+
+/** @component */
+export default IconRow

--- a/src/components/pressQuotes/__snapshots__/pressQuotes.test.js.snap
+++ b/src/components/pressQuotes/__snapshots__/pressQuotes.test.js.snap
@@ -4,30 +4,51 @@ exports[`(Styled Component) PressQuotes matching the snapshot 1`] = `
 <Styled(BasePressQuotes)
   constrained={true}
   header="BUZZZZZZZZZ"
-  order={
-    Array [
-      "new_york_times",
-      "today_show",
-      "people_magazine",
-      "tech_crunch",
-      "fast_company",
-      "parents_magazine",
-      "la_times",
-      "new_york_post",
-    ]
-  }
+  headerLabel="What's the buzz?"
   padding={true}
   quotes={
-    Object {
-      "fast_company": "“Shopping for kids’ clothes can be fun.”",
-      "la_times": "“Obsessively kid friendly.”",
-      "new_york_post": "“The witty graphics, throwback bombers and metallic-accented tutus from this fashion-forward label are all about encouraging kids 'to be their authentic selves.'",
-      "new_york_times": "“Materials and details are thoughtful, and the clothes are wildly cute.”",
-      "parents_magazine": "“You can’t buy these clothes in stores.”",
-      "people_magazine": "“They'll be at the top of their playground game with these clothes.”",
-      "tech_crunch": "“Rockets of Awesome is a total no brainer.”",
-      "today_show": "“The clothing is so stylish and so affordable...and the softest quality.”",
-    }
+    Array [
+      Object {
+        "id": "new_york_times",
+        "name": "The New York Times",
+        "quote": "“Materials and details are thoughtful, and the clothes are wildly cute.”",
+      },
+      Object {
+        "id": "today_show",
+        "name": "Today Show",
+        "quote": "“The clothing is so stylish and so affordable...and the softest quality.”",
+      },
+      Object {
+        "id": "people_magazine",
+        "name": "People Magazine",
+        "quote": "“They'll be at the top of their playground game with these clothes.”",
+      },
+      Object {
+        "id": "tech_crunch",
+        "name": "Tech Crunch",
+        "quote": "“Rockets of Awesome is a total no brainer.”",
+      },
+      Object {
+        "id": "fast_company",
+        "name": "Fast Company",
+        "quote": "“Shopping for kids’ clothes can be fun.”",
+      },
+      Object {
+        "id": "parents_magazine",
+        "name": "Parent's Magazine",
+        "quote": "“You can’t buy these clothes in stores.”",
+      },
+      Object {
+        "id": "la_times",
+        "name": "The L.A. Times",
+        "quote": "“Obsessively kid friendly.”",
+      },
+      Object {
+        "id": "new_york_post",
+        "name": "The New York Post",
+        "quote": "“The witty graphics, throwback bombers and metallic-accented tutus from this fashion-forward label are all about encouraging kids 'to be their authentic selves.'",
+      },
+    ]
   }
   theme={
     Object {

--- a/src/components/pressQuotes/defaultProps.js
+++ b/src/components/pressQuotes/defaultProps.js
@@ -1,14 +1,46 @@
 export default {
-  "header": "BUZZZZZZZZZ",
-  "quotes": {
-    new_york_times: '“Materials and details are thoughtful, and the clothes are wildly cute.”',
-    today_show: '“The clothing is so stylish and so affordable...and the softest quality.”',
-    people_magazine: '“They\'ll be at the top of their playground game with these clothes.”',
-    tech_crunch: '“Rockets of Awesome is a total no brainer.”',
-    fast_company: '“Shopping for kids’ clothes can be fun.”',
-    parents_magazine: '“You can’t buy these clothes in stores.”',
-    la_times: '“Obsessively kid friendly.”',
-    new_york_post: '“The witty graphics, throwback bombers and metallic-accented tutus from this fashion-forward label are all about encouraging kids \'to be their authentic selves.\''
-  },
-  "order": ["new_york_times", "today_show", "people_magazine", "tech_crunch", "fast_company", "parents_magazine", "la_times", "new_york_post"]
+  header: 'BUZZZZZZZZZ',
+  headerLabel: 'What\'s the buzz?',
+  quotes: [
+    {
+      id: 'new_york_times',
+      quote: '“Materials and details are thoughtful, and the clothes are wildly cute.”',
+      name: 'The New York Times'
+    },
+    {
+      id: 'today_show',
+      quote: '“The clothing is so stylish and so affordable...and the softest quality.”',
+      name: 'Today Show'
+    },
+    {
+      id: 'people_magazine',
+      quote: '“They\'ll be at the top of their playground game with these clothes.”',
+      name: 'People Magazine'
+    },
+    {
+      id: 'tech_crunch',
+      quote: '“Rockets of Awesome is a total no brainer.”',
+      name: 'Tech Crunch'
+    },
+    {
+      id: 'fast_company',
+      quote: '“Shopping for kids’ clothes can be fun.”',
+      name: 'Fast Company'
+    },
+    {
+      id: 'parents_magazine',
+      quote: '“You can’t buy these clothes in stores.”',
+      name: 'Parent\'s Magazine'
+    },
+    {
+      id: 'la_times',
+      quote: '“Obsessively kid friendly.”',
+      name: 'The L.A. Times'
+    },
+    {
+      id: 'new_york_post',
+      quote: '“The witty graphics, throwback bombers and metallic-accented tutus from this fashion-forward label are all about encouraging kids \'to be their authentic selves.\'',
+      name: 'The New York Post'
+    }
+  ],
 }

--- a/src/modules/forms/__snapshots__/DefaultSection.test.js.snap
+++ b/src/modules/forms/__snapshots__/DefaultSection.test.js.snap
@@ -43,7 +43,7 @@ exports[`(Styled Component) DefaultSection matching the snapshot 1`] = `
 
 @media (min-width:76.8em) {
   .c0 .sc-uJMKN,
-  .c0 .sc-jtRfpW {
+  .c0 .sc-kTUwUJ {
     margin: 0 2rem;
   }
 }


### PR DESCRIPTION
[Delivers: #164644428 #164644184]

This PR addresses two issues.

* The screen reader has some pronunciation issues with the header and
some of the quotes. I updated an aria label for the header so that it
reads out: "What's the buzz?" and I fixed the quotes so that the L.A.
Times is rad out correctly.
* Updated the PressQuotes so that the timer gets reset when the chevrons
or logos are clicked.
* Touched up some styling issues with the chevrons so that the width
remains consistent.
* Cleaned up some code structure