### PR TITLE
Making Breakpoint Component SSR Friendly

### DIFF
--- a/src/components/breakpoints/index.js
+++ b/src/components/breakpoints/index.js
@@ -1,8 +1,80 @@
 import React from 'react'
-import Responsive from 'react-responsive'
-import { sizes } from 'SRC/core/theme/breakpoints'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
-export const Desktop = props => <Responsive {...props} minDeviceWidth={sizes.desktop} />;
-export const Tablet = props => <Responsive {...props} minDeviceWidth={sizes.tablet} maxDeviceWidth={sizes.desktop} />;
-export const Mobile = props => <Responsive {...props} maxDeviceWidth={sizes.tablet - 1} />;
-export const Default = props => <Responsive {...props} minDeviceWidth={sizes.tablet} />;
+const Desktop = styled(({element, children, ...props}) => {
+  return React.createElement(element, props, children)
+})`
+display: none;
+${props => props.theme.breakpointsVerbose.aboveLaptop`
+  display: block;
+`}
+`
+
+Desktop.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  element: PropTypes.node
+}
+Desktop.defaultProps = {
+  element: 'div'
+}
+
+const Tablet = styled(({element, children, ...props}) => {
+  return React.createElement(element, props, children)
+})`
+display: none;
+${props => props.theme.breakpointsVerbose.aboveTablet`
+  display: block;
+`}
+${props => props.theme.breakpointsVerbose.abovelaptop`
+  display: none;
+`}
+`
+
+Tablet.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  element: PropTypes.node
+}
+Tablet.defaultProps = {
+  element: 'div'
+}
+
+const Mobile = styled(({element, children, ...props}) => {
+  return React.createElement(element, props, children)
+})`
+display: block;
+${props => props.theme.breakpointsVerbose.aboveTablet`
+  display: none;
+`}
+`
+
+Mobile.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  element: PropTypes.node
+}
+Mobile.defaultProps = {
+  element: 'div'
+}
+
+const Default = styled(({element, children, ...props}) => {
+  return React.createElement(element, props, children)
+})`
+display: none;
+${props => props.theme.breakpointsVerbose.belowLaptop`
+  display: block;
+`}
+`
+
+Default.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  element: PropTypes.node
+}
+Default.defaultProps = {
+  element: 'div'
+}
+
+export {Desktop, Tablet, Mobile, Default}

--- a/src/core/theme/breakpoints.js
+++ b/src/core/theme/breakpoints.js
@@ -34,3 +34,14 @@ export default Object.keys(sizes).reduce((accumulator, label) => {
   `
   return accumulator
 }, {})
+
+export const breakpointsVerbose = Object.keys(breakpoints).reduce((accumulator, label) => {
+  // use em in breakpoints to work properly cross-browser and support users
+  // changing their browsers font-size: https://zellwk.com/blog/media-query-units/
+  accumulator[label] = (...args) => css`
+    @media ${breakpoints[label]} {
+      ${css(...args)}
+    }
+  `
+  return accumulator
+}, {})

--- a/src/core/theme/theme.js
+++ b/src/core/theme/theme.js
@@ -1,6 +1,6 @@
 import { injectGlobal } from 'styled-components'
 import { colors } from './colors'
-import media, { breakpoints } from './breakpoints'
+import media, { breakpoints, breakpointsVerbose } from './breakpoints'
 import fontFamilies from './fontFamilies'
 import gridSettings from './gridSettings'
 
@@ -17,5 +17,6 @@ export default {
   grid: gridSettings,
   fixedPosition: 'relative',
   media: media,
+  breakpointsVerbose: breakpointsVerbose,
   base: base
 }


### PR DESCRIPTION
#### What does this PR do?
Based off of a comment that @jrusso1020 had made in the breakpoint
components, we went back and converted the Breakpoint components to
utilize CSS instead of React Responsive. The components should hopefully
have the same functionality however, they should be able to work even if
they are server side rendered!

#### Screenshots


#### Notes


#### PR Dependencies


#### Relevant Tickets
