### PR TITLE
Adding the responsive header component

### DIFF
--- a/src/modules/header/header.js
+++ b/src/modules/header/header.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { Desktop, Default, DesktopNavigation, MobileNavigation } from 'SRC'
+
+const Header = ({className, mobileProps, desktopProps}) => {
+  return (
+    <div className={className}>
+      <Default>
+        <MobileNavigation {...mobileProps} />
+      </Default>
+      <Desktop>
+        <DesktopNavigation {...desktopProps} />
+      </Desktop>
+    </div>
+  )
+}
+
+Header.propTypes = {
+
+}
+
+Header.defaultProps = {
+  position: 'fixed'
+}
+
+/** @component */
+export default Header

--- a/src/modules/header/header.md
+++ b/src/modules/header/header.md
@@ -1,0 +1,16 @@
+```js
+  <div style={{position: 'relative', height: '70rem'}}>
+    <Header
+      mobileProps={
+        {
+          position: 'absolute',
+          drawerPosition:'absolute'
+        }
+      }
+      desktopProps={
+        {
+          position: 'static'
+        }
+      } />
+    </div>
+```

--- a/src/modules/header/index.js
+++ b/src/modules/header/index.js
@@ -1,2 +1,4 @@
 export * from './desktopNavigation'
 export * from './mobileNavigation'
+
+export { default as Header } from './header'


### PR DESCRIPTION
#### What does this PR do?
This PR simply adds a component that renders out the DesktopHeader when
on a Desktop breakpoint and Mobile when not on a Desktop breakpoint.


#### Screenshots

![mirage-header](https://user-images.githubusercontent.com/1794777/56444645-8ae83b00-62c7-11e9-8cda-dcd5bd570156.gif)

#### Notes


#### PR Dependencies


#### Relevant Tickets
