### PR TITLE
Introducing Contentful to Mirage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1863,6 +1863,24 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.0-beta.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0-beta.1.tgz",
+      "integrity": "sha512-Dizm4IyB5T9OrREhPgbqUSofTOjhNJoc+CLjUtyH8SQUyFfik777lLjhl9cVQ4oo3bykkPAN20rxmY1o5w0jrw==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.4.1",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+          "dev": true
+        }
+      }
+    },
     "axobject-query": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
@@ -4353,6 +4371,38 @@
       "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
       "dev": true
     },
+    "contentful": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-7.6.0.tgz",
+      "integrity": "sha512-JWj6/NYTvy+FlB8YQoSEr6LNKH3y9knwKabehzaJfTyAQ3Kpv230uh0SR5vddxSHbzCnQGhqa4pLYmbyy1749w==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.19.0-beta.1",
+        "contentful-resolve-response": "^1.1.4",
+        "contentful-sdk-core": "^6.3.2",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.11"
+      }
+    },
+    "contentful-resolve-response": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.1.4.tgz",
+      "integrity": "sha512-oFq6n6zjbiwD9/7mBa8YHPwvPM0B0D4uOgg1n/rVzpQPhCrzeIixNj6fbJAbDiJt05rZqxiY3K1Db7pPRhRaZw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "contentful-sdk-core": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.3.3.tgz",
+      "integrity": "sha512-8mn9844B2sCj5jNJJTWEqblKwVmfj71Srur2n/Ig/xqwlAJXuIIQ4yGT0CtnljELtKUN1omIMgVnVJB+9iGMnQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10",
+        "qs": "^6.5.2"
+      }
+    },
     "convert-source-map": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -6785,7 +6835,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6806,12 +6857,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6826,17 +6879,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6953,7 +7009,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6965,6 +7022,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6979,6 +7037,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6986,12 +7045,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7010,6 +7071,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7090,7 +7152,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7102,6 +7165,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7187,7 +7251,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7223,6 +7288,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7242,6 +7308,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7285,12 +7352,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-runtime": "6.26.0",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",
+    "contentful": "^7.6.0",
     "css-loader": "0.28.7",
     "dotenv": "4.0.0",
     "dotenv-expand": "4.2.0",

--- a/src/components/contentful/image/contentfulImage.js
+++ b/src/components/contentful/image/contentfulImage.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { InlineImage } from 'SRC'
+const ContentfulImage = ({className, fields: {description, file: {url}}}) => {
+  return (<InlineImage className={className} alt={description} src={url} />)
+}
+ContentfulImage.propTypes = {
+  fields: PropTypes.shape({
+    description: PropTypes.string,
+    file: PropTypes.shape({
+      url: PropTypes.string
+    })
+  })
+}
+/** @component */
+export default ContentfulImage

--- a/src/components/contentful/image/contentfulImage.md
+++ b/src/components/contentful/image/contentfulImage.md
@@ -1,0 +1,5 @@
+```js
+  <Contentful operation='getAsset' id='VY7BmW2jtHaLTjQEQKe3t'>
+    <ContentfulImage/>
+  </Contentful>
+```

--- a/src/components/contentful/image/contentfulImage.test.js
+++ b/src/components/contentful/image/contentfulImage.test.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { css } from 'styled-components'
+import 'jest-styled-components'
+
+import ContentfulImage from './contentfulImage'
+
+const { mountWithTheme } = global
+
+const defaultProps = {
+  fields: {
+    description: 'An example tag',
+    file: {
+      url: 'https://www.example.com/img.jpg'
+    }
+  }
+}
+describe('(Component) ContentfulImage', () => {
+  const createContentfulImage = (inProps) => {
+    const props = {
+      ...defaultProps,
+      ...inProps
+    }
+    return mountWithTheme(<ContentfulImage {...props} />)
+  }
+
+  test('matching the snapshot', () => {
+    expect(createContentfulImage())
+    .toMatchSnapshot()
+  })
+
+  test('description is passed to img alt attribute', () => {
+    expect(
+      createContentfulImage()
+      .find('img')
+      .prop('alt')
+    ).toEqual(defaultProps.fields.description)
+  })
+
+  test('file url is passed to img src attribute', () => {
+    expect(
+      createContentfulImage()
+      .find('img')
+      .prop('src')
+    ).toEqual(defaultProps.fields.file.url)
+  })
+})

--- a/src/components/contentful/image/index.js
+++ b/src/components/contentful/image/index.js
@@ -1,0 +1,1 @@
+export { default as ContentfulImage } from './ContentfulImage'

--- a/src/components/contentful/index.js
+++ b/src/components/contentful/index.js
@@ -1,0 +1,1 @@
+export * from 'image'

--- a/src/services/contentful.js
+++ b/src/services/contentful.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { createClient } from 'contentful'
+
+let client
+
+function initContentful () {
+  let host = 'cdn.contentful.com'
+  if (parseInt(process.env.REACT_APP_CONTENTFUL_PREVIEW, 10) === 1) {
+    host = 'preview.contentful.com'
+  }
+  client = createClient({
+    space: process.env.REACT_APP_CONTENTFUL_SPACE_KEY,
+    accessToken: process.env.REACT_APP_CONTENTFUL_ACCESS_TOKEN,
+    host: host
+  })
+  return client.getSpace()
+    .then((space) => {
+      return space
+    })
+}
+
+function getClient () {
+  return client
+}
+
+export const loadEntry = (query) => {
+  return getClient().getEntry(query)
+}
+export const loadEntries = (query) => {
+  if (getClient().getEntries) {
+    return getClient().getEntries(query)
+  } else {
+    return null
+  }
+}
+
+export { initContentful, getClient }
+
+initContentful()
+
+export default class Contentful extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      response: null
+    }
+  }
+  componentDidMount() {
+    const { operation: inOp, id } = this.props
+    const client = getClient()
+    try {
+      const operation = client[inOp]
+      operation(id).then((response) => {
+        this.setState({response: response})
+      })
+    } catch (err) {
+      console.warn(err)
+    }
+  }
+  render() {
+    const { children } = this.props
+    const { response } = this.state
+    if (response) {
+      return React.createElement(children.type, {...response})
+    } else {
+      return null
+    }
+  }
+}
+
+
+
+Contentful.propTypes = {
+  operation: PropTypes.string
+}

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -8,6 +8,9 @@ module.exports = {
   title: 'Mirage - ROA Pattern Library',
   webpackConfig: require(env[process.env.NODE_ENV]),
   components: 'src/**/*.{js,jsx,ts,tsx}',
+  require: [
+    path.join(__dirname, 'src/services/contentful.js')
+  ],
   styleguideComponents: {
     Wrapper: path.join(__dirname, 'src/core/theme')
   },


### PR DESCRIPTION
#### What does this PR do?
This PR introduces Contentful as a development dependency to the Mirage
codebase. We also created a Contentful React component that allows
developers to make a call to Contentful to then get real data back from
the contentful service. Since Contentful is installed as a development
dependency it shouldn't be included when installing a later version of
Mirage thus creating conflicting version of Contentful. The Contenful
component itself is also not being exported as a component currently, if
we decide that it might be easier to utilize it as component then we
could include it in the main index.js export of Mirage.

This PR also includes the first example using the Contentful component
the ContentfulImage component. We pass the operation to `getAsset` and
the `id` of the image asset from:
https://app.contentful.com/spaces/efh696jqykjs/assets/VY7BmW2jtHaLTjQEQKe3t
and it then gets the response data from Contentful and properly passes
it down to an `InlineImage` component.

#### Screenshots

![Screen Shot 2019-05-24 at 2 54 16 PM](https://user-images.githubusercontent.com/1794777/58350422-d5fbed80-7e33-11e9-826e-520e9e2acb36.png)

#### Notes
In order to test this PR, you need to include the following keys in your .env:

REACT_APP_CONTENTFUL_SPACE_KEY, REACT_APP_CONTENTFUL_ACCESS_TOKEN, and REACT_APP_CONTENTFUL_PREVIEW

#### PR Dependencies


#### Relevant Tickets
[#166166021]