### PR TITLE
Ensure the bag icon on mobile is clickable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.236",
+  "version": "0.1.237",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.236",
+  "version": "0.1.237",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/header/mobileNavigation/mobileNavigation.js
+++ b/src/modules/header/mobileNavigation/mobileNavigation.js
@@ -59,7 +59,9 @@ export class BaseMobileNavigation extends React.Component {
         <MobileHeader>
           <BlueHamburger onClick={this.openDrawer} />
           <Logo />
-          <BagIcon onClick={clickBag} count={bagCount}/>
+          <a onClick={clickBag}>
+            <BagIcon count={bagCount} />
+          </a>
         </MobileHeader>
         <MenuDrawer
           open={open}

--- a/src/modules/header/mobileNavigation/mobileNavigation.md
+++ b/src/modules/header/mobileNavigation/mobileNavigation.md
@@ -8,7 +8,9 @@ _Note: The drawerPosition and position props are only used to constrain the mobi
       position='absolute'
       boysLinks={require('./defaultProps').boysLinks}
       girlsLinks={require('./defaultProps').girlsLinks}
-      renderLink={require('./defaultProps').renderLink} />
+      renderLink={require('./defaultProps').renderLink}
+      clickBag={() => console.log('Bag clicked')}
+    />
     <img style={{maxWidth: '100%'}} src='https://www.fillmurray.com/g/500/700' />
   </div>
 ```


### PR DESCRIPTION
#### What does this PR do?
With this change we'll wrap the bag icon on the mobile navigation to ensure the clickBag listener is
triggered when the customers actually click on the icon.

It seem like `<svg />` components don't respond to the `onClick` property, so we'll wrap the component in an anchor tag