### PR TITLE
[Fixes #166942152] Fix bug to remove promotion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.253",
+  "version": "0.1.254",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.253",
+  "version": "0.1.254",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/couponCode/removeCouponCode.js
+++ b/src/components/couponCode/removeCouponCode.js
@@ -2,9 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-export class BaseRemoveCouponCode extends React.Component {
+class BaseRemoveCouponCode extends React.Component {
   removePromoCode = () => {
-    const {removePromotion, promotion} = this.props
+    const { removePromotion, promotion } = this.props
     removePromotion(promotion)
   }
   render () {
@@ -23,7 +23,7 @@ BaseRemoveCouponCode.propTypes = {
   className: PropTypes.string
 }
 
-const RemoveCouponCode = styled.div`
+const RemoveCouponCode = styled(BaseRemoveCouponCode)`
   font-family: ${props => props.theme.fonts.primaryFont};
   font-size: 14px;
   font-weight: 400;


### PR DESCRIPTION
#### What does this PR do?

Fixes bug that prevents user from removing promotion.

Correctly references `BaseRemoveCouponCode`, which then displays on the page.

#### Relevant Tickets

- https://www.pivotaltracker.com/n/projects/2089973/stories/166942152