### PR TITLE
Inline Images can be Lazy Loaded

### DIFF
--- a/src/components/images/slider/slider.base.js
+++ b/src/components/images/slider/slider.base.js
@@ -47,7 +47,7 @@ export class BaseROASlider extends Component {
   }
 
   render() {
-    const { className, images, renderLink, target } = this.props
+    const { className, images, renderLink, target, ...props } = this.props
     const Link = renderLink
     return (
       <div
@@ -68,7 +68,9 @@ export class BaseROASlider extends Component {
                   src={cloudinary.url(image.src, {
                     transformation: 'plp_product_shot',
                     format: 'jpg'
-                  })} />
+                  })}
+                  {...props}
+                   />
                 </Link>
               )
             } else {

--- a/src/core/image/__snapshots__/inlineImage.test.js.snap
+++ b/src/core/image/__snapshots__/inlineImage.test.js.snap
@@ -1,8 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`(Styled Component) InlineImage When no props are provided matching the snapshot 1`] = `
-<img
+<InlineImage
   alt=""
   src="https://dummyInlineImage.com/100x100/CCC/333.png&text=small"
-/>
+>
+  <img
+    alt=""
+    src="https://dummyInlineImage.com/100x100/CCC/333.png&text=small"
+  />
+</InlineImage>
 `;

--- a/src/core/image/inlineImage.js
+++ b/src/core/image/inlineImage.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import Sizes from './sizes.base'
 import SourceSet from './sourceSet.base'
 
-const InlineImage = ({alt, src, sizes: inSizes, srcSet: inSources, ...props }) => {
+const InlineImage = ({alt, src, sizes: inSizes, srcSet: inSources, lazyLoad, ...props }) => {
     let srcSet =  undefined
     if (inSources) {
       srcSet = new SourceSet(inSources).toString()
@@ -13,14 +13,25 @@ const InlineImage = ({alt, src, sizes: inSizes, srcSet: inSources, ...props }) =
     if (inSizes) {
       sizesStr = new Sizes(inSizes).toString()
     }
-    return (
-      <img
-        alt={alt}
-        src={src}
-        srcSet={srcSet}
-        sizes={sizesStr}
-        {...props} />
-    )
+    if (!lazyLoad) {
+      return (
+        <img
+          alt={alt}
+          src={src}
+          srcSet={srcSet}
+          sizes={sizesStr}
+          {...props} />
+      )
+    } else {
+      return (
+        <img
+          alt={alt}
+          data-src={src}
+          srcSet={srcSet}
+          sizes={sizesStr}
+          {...props} />
+      )
+    }
 }
 
 InlineImage.defaultProps = {
@@ -29,6 +40,7 @@ InlineImage.defaultProps = {
 
 InlineImage.propTypes = {
   alt: PropTypes.string.isRequired,
+  lazyLoad: PropTypes.bool,
   src: PropTypes.string.isRequired,
   sizes: PropTypes.object,
   srcSet: PropTypes.oneOfType([

--- a/src/core/image/inlineImage.md
+++ b/src/core/image/inlineImage.md
@@ -34,3 +34,8 @@ and also check out the specifications
     }
     />
 ```
+
+### Setting LazyLoad (image should have data-src set instead of src):
+```js
+  <InlineImage src='https://www.fillmurray.com/g/100/100' lazyLoad={true} />
+```

--- a/src/core/image/inlineImage.test.js
+++ b/src/core/image/inlineImage.test.js
@@ -3,7 +3,7 @@ import 'jest-styled-components'
 
 import { InlineImage } from 'SRC'
 
-const { shallowWithTheme } = global
+const { mountWithTheme } = global
 
 describe('(Styled Component) InlineImage', () => {
   const defaultProps = {
@@ -14,7 +14,7 @@ describe('(Styled Component) InlineImage', () => {
       ...defaultProps,
       ...inProps
     }
-    return shallowWithTheme(<InlineImage  {...props} />)
+    return mountWithTheme(<InlineImage  {...props} />)
   }
 
   describe('When no props are provided', () => {
@@ -68,5 +68,10 @@ const sizesString = `800px (min-width: 500px),
       expect(InlineImageComponent.find('img').prop('srcSet')).toEqual(srcSetString)
       expect(InlineImageComponent.find('img').prop('sizes')).toContain(sizesString)
     })
+  })
+  
+  test('data-src is set when lazyLoad prop is passed', () => {
+    expect(createInlineImage({lazyLoad: true}).find('img').prop('src')).toEqual(undefined)
+    expect(createInlineImage({lazyLoad: true}).find('img').prop('data-src')).toEqual(defaultProps.src)
   })
 })

--- a/src/modules/productTile/productTile.base.js
+++ b/src/modules/productTile/productTile.base.js
@@ -62,7 +62,8 @@ export default class ProductTile extends React.Component {
             product={product}
             shots={colorway.shots}
             renderLink={renderLink}
-            target={target} />
+            target={target}
+            {...props} />
         </QuickAdd>
         { (renderLink && target) ?
           <Link


### PR DESCRIPTION
#### What does this PR do?
[#167436130]

This PR adds the ability to lazy load images. If the `lazyLoad` prop is passed to the `InlineImage` we will not set the `src` attribute on the `img` element but will set a `data-src` attribute which can then be interacted with a HOC to load in images if the element is in the current viewport.

#### Screenshots


#### Notes


#### PR Dependencies


#### Relevant Tickets
