### PR TITLE
[Fixes #167469094] Sign out from mobile menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.328",
+  "version": "0.1.329",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.328",
+  "version": "0.1.329",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/header/mobileNavigation/accountLinks/mobileAccountLinks.js
+++ b/src/modules/header/mobileNavigation/accountLinks/mobileAccountLinks.js
@@ -8,7 +8,7 @@ import {
   UL
 } from 'SRC'
 
-const BaseAccountLinks = ({className, renderLink, isSubscriptionMember}) => {
+const BaseAccountLinks = ({ className, renderLink, isSubscriptionMember, signOut }) => {
   return (
     <div>
       <Accordion
@@ -67,7 +67,9 @@ const BaseAccountLinks = ({className, renderLink, isSubscriptionMember}) => {
           }
         </UL>
       </Accordion>
-      <MobileLinkTop className='roa-logout-link'>
+      <MobileLinkTop
+        className='roa-logout-link'
+        onClick={signOut}>
         Log out
       </MobileLinkTop>
     </div>
@@ -80,11 +82,13 @@ const MobileAccountLinks = styled(BaseAccountLinks)`
 
 MobileAccountLinks.propTypes = {
   renderLink: PropTypes.func,
-  isSubscriptionMember: PropTypes.bool
+  isSubscriptionMember: PropTypes.bool,
+  signOut: PropTypes.func
 }
 
 MobileAccountLinks.defaultProps = {
-  isSubscriptionMember: false
+  isSubscriptionMember: false,
+  signOut: () => alert('Signing out')
 }
 /** @component */
 export default MobileAccountLinks

--- a/src/modules/header/mobileNavigation/mobileNavigation.js
+++ b/src/modules/header/mobileNavigation/mobileNavigation.js
@@ -49,7 +49,8 @@ export class BaseMobileNavigation extends React.Component {
       bagCount,
       clickBag,
       showBlog,
-      outfitNav
+      outfitNav,
+      signOut
     } = this.props
 
     const { open } = this.state
@@ -193,7 +194,8 @@ export class BaseMobileNavigation extends React.Component {
             {loggedIn &&
               <MobileAccountLinks
                 isSubscriptionMember={isSubscriptionMember}
-                renderLink={renderLink} />
+                renderLink={renderLink}
+                signOut={signOut} />
             }
           </UL>
         </MenuDrawer>


### PR DESCRIPTION
#### What does this PR do?

Adds signing out to mobile menu.

Passes `signOut` function down to an `onClick` on `MobileLinkTop`.

#### PR Dependencies

- `thor` PR TBA

#### Relevant Tickets

- [Fixes #167469094]
    - https://www.pivotaltracker.com/n/projects/2089973/stories/167469094