### PR TITLE
167436130 Fixes slider images in lazyLoad

### DIFF
--- a/src/components/images/slider/slider.base.js
+++ b/src/components/images/slider/slider.base.js
@@ -54,6 +54,7 @@ export class BaseROASlider extends Component {
   render() {
     const { className, images, renderLink, target, ...props } = this.props
     delete props.onLazyLoad
+    delete props.lazyLoad
     const Link = renderLink
     return (
       <div


### PR DESCRIPTION
#### What does this PR do?

Adds back in `delete props.lazyLoad` to the slider because secondary images in the lazy loaded product tiles are broken. 

Checked homepage and PDP product tiles on local and they are working with this change.

#### Relevant Tickets

[Delivers #167436130]
