### PR TITLE
[Fixes #167408546] Fix visibility of secondary photos

### DIFF
--- a/src/components/images/slider/slider.base.js
+++ b/src/components/images/slider/slider.base.js
@@ -7,6 +7,12 @@ import { InlineImage, Chevron } from 'SRC'
 export class BaseROASlider extends Component {
   constructor (props) {
     super(props)
+
+    this.state = {
+      currentSlide: 0,
+      transition: false
+    }
+
     this.config = {
       infinite: true,
       arrows: false,
@@ -19,8 +25,16 @@ export class BaseROASlider extends Component {
             dotsClass: 'dots'
           }
         }
-      ]
+      ],
+      beforeChange: (current, next) => {
+        this.setState({
+          currentSlide: next,
+          transition: true
+        })
+      },
+      afterChange: () => this.setState({ transition: false })
     }
+    
     if (props.sliderLazyLoad) {
       this.config.lazyLoad = props.sliderLazyLoad
     }
@@ -48,6 +62,12 @@ export class BaseROASlider extends Component {
     this.slider && this.slider.slickNext()
   }
 
+  isVisible = (index) => {
+    if (this.state.currentSlide === index) return true
+
+    return this.state.transition
+  }
+
   render() {
     const { className, images, renderLink, target, ...props } = this.props
     const Link = renderLink
@@ -71,6 +91,7 @@ export class BaseROASlider extends Component {
                     transformation: 'plp_product_shot',
                     format: 'jpg'
                   })}
+                  visible={this.isVisible(index)}
                   {...props}
                    />
                 </Link>

--- a/src/core/image/inlineImage.js
+++ b/src/core/image/inlineImage.js
@@ -13,6 +13,11 @@ const InlineImage = ({alt, src, sizes: inSizes, srcSet: inSources, lazyLoad, ...
     if (inSizes) {
       sizesStr = new Sizes(inSizes).toString()
     }
+
+    let visibility = "visible"
+    if (!props.visible) {
+      visibility = "hidden"
+    }
     if (!lazyLoad) {
       return (
         <img
@@ -20,6 +25,7 @@ const InlineImage = ({alt, src, sizes: inSizes, srcSet: inSources, lazyLoad, ...
           src={src}
           srcSet={srcSet}
           sizes={sizesStr}
+          style={{visibility: visibility}}
           {...props} />
       )
     } else {
@@ -29,18 +35,21 @@ const InlineImage = ({alt, src, sizes: inSizes, srcSet: inSources, lazyLoad, ...
           data-src={src}
           srcSet={srcSet}
           sizes={sizesStr}
+          style={{visibility: visibility}}
           {...props} />
       )
     }
 }
 
 InlineImage.defaultProps = {
-  alt: ''
+  alt: '',
+  visible: true
 }
 
 InlineImage.propTypes = {
   alt: PropTypes.string.isRequired,
   lazyLoad: PropTypes.string,
+  visible: PropTypes.bool,
   src: PropTypes.string.isRequired,
   sizes: PropTypes.object,
   srcSet: PropTypes.oneOfType([


### PR DESCRIPTION
#### What does this PR do?

Gives styling `visibility: hidden` to photos that are not the current slick slider photo.

The bug is in the slick slider product images on the Thor PLPs where some photos show ~1px on the left or right side of the next photo in the slider. By removing the visibility of the non-current photo, it doesn't impact the slider position and fixes the places where this is an issue.

#### Relevant Tickets

- [Delivers #167408546]
  - https://www.pivotaltracker.com/n/projects/2089973/stories/167408546
