### PR TITLE
Adding a default height for lazy-loaded images

### DIFF
--- a/src/components/images/slider/slider.js
+++ b/src/components/images/slider/slider.js
@@ -104,7 +104,11 @@ position: relative;
 a {
   position: relative;
   width: 100%;
+  padding-bottom: 150%;
   img {
+    position: absolute;
+    top: 0;
+    left: 0;
     pointer-events: none
     width: 100%;
   }


### PR DESCRIPTION
#### What does this PR do?
[#167476520]

Adding a preset height for the images that are lazy loaded in. My hope
is that this might help with the scroll position issue that we are
witnessing on the PLP.

#### Screenshots


#### Notes


#### PR Dependencies


#### Relevant Tickets
