### PR TITLE
[Fixes #167623464] Let H1 take line-height props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.349",
+  "version": "0.1.350",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.349",
+  "version": "0.1.350",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/core/typography/H1.js
+++ b/src/core/typography/H1.js
@@ -18,7 +18,10 @@ const H1 = styled.h1`
     font-size: ${props => props.fontSizes.desktop};
   `}
   font-weight: 500;
-  line-height:1.0476190476190477;
+  line-height: ${props => props.lineHeights.mobile};
+  ${props => props.theme.breakpointsVerbose.aboveTablet`
+    line-height: ${props => props.lineHeights.desktop};
+  `}
   margin: ${props => props.margin};
 `
 
@@ -44,7 +47,11 @@ H1.defaultProps = {
     desktop: '4.2rem',
     mobile: '3.2rem'
   },
-  margin: '5.5rem 0'
+  margin: '5.5rem 0',
+  lineHeights: {
+    desktop: 1.0476190476190477,
+    mobile: 1.3
+  }
 }
 
 /** @component */

--- a/src/core/typography/__snapshots__/H1.test.js.snap
+++ b/src/core/typography/__snapshots__/H1.test.js.snap
@@ -9,14 +9,25 @@ exports[`(Styled Component) H1 matching the snapshot 1`] = `
   text-transform: uppercase;
   color: #00003C;
   font-family: "din-cond","din-condensed-web",Arial,sans-serif;
-  font-size: 4.2rem;
+  font-size: 3.2rem;
   font-weight: 500;
-  line-height: 1.0476190476190477;
+  line-height: 1.3;
   margin: 5.5rem 0;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    font-size: 4.2rem;
+  }
+}
+
+@media (min-width:768px) {
+  .c0 {
+    line-height: 1.0476190476190477;
+  }
 }
 
 <h1
   className="c0"
-  fontSize="4.2rem"
 />
 `;


### PR DESCRIPTION
#### What does this PR do?

Allows `H1` styled component to accept line-height props for desktop and mobile.

#### Relevant Tickets

- [Delivers #167623464]
  - https://www.pivotaltracker.com/n/projects/2089973/stories/167623464