### PR TITLE
[Fixes #167856738] Makes iPhone 5 navigation logo smaller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.372",
+  "version": "0.1.373",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.372",
+  "version": "0.1.373",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/core/icons/Logo/Logo.base.js
+++ b/src/core/icons/Logo/Logo.base.js
@@ -124,10 +124,14 @@ const animated = css`
 `
 
 const BaseLogo = styled(UnstyledBaseLogo)`
-  width: 100%;
+  width: 168px;
 
-  ${props => props.theme.breakpointsVerbose.belowTablet`
+  ${props => props.theme.breakpointsVerbose.abovePhone`
     width: 215px;
+  `}
+
+  ${props => props.theme.breakpointsVerbose.aboveTablet`
+    width: 100%;
   `}
 
   max-width: ${props => props.maxWidth};

--- a/src/core/theme/mediaQueries.js
+++ b/src/core/theme/mediaQueries.js
@@ -1,7 +1,7 @@
 import { css } from 'styled-components'
 
 const sizes = {
-  phone: 320,
+  phone: 321,
   phoneMax: 414,
   tablet: 768,
   mobileNav: 889,


### PR DESCRIPTION
#### What does this PR do?

Makes the iPhone 5 navigation logo smaller so that the cart indicator icon will not get cut off by the screen.

This change will make the size of logo on Thor match Quark UI.

The `phone` media query width is modified so that the iPhone 5 can be styled separately from the later version iPhones as we can do in Quark UI. `breakpointsVerbose.abovePhone` (not previously used) will target devices 321px wide and larger.

#### PR Dependencies

Dependent on updating Mirage version on Thor.

#### Relevant Tickets

- [Fixes #167856738]
  - https://www.pivotaltracker.com/story/show/167856738

