### PR TITLE
[#167954762] Hide noncurrent item cards on PLP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.377",
+  "version": "0.1.378",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.377",
+  "version": "0.1.378",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/images/slider/slider.base.js
+++ b/src/components/images/slider/slider.base.js
@@ -7,6 +7,12 @@ import { InlineImage, Chevron } from 'SRC'
 export class BaseROASlider extends Component {
   constructor (props) {
     super(props)
+
+    this.state = {
+      currentSlideId: 0,
+      transitioning: false
+    }
+
     this.config = {
       infinite: true,
       arrows: false,
@@ -19,8 +25,16 @@ export class BaseROASlider extends Component {
             dotsClass: 'dots'
           }
         }
-      ]
+      ],
+      beforeChange: (currentSlideId, nextSlideId) => {
+        this.setState({
+          currentSlideId: nextSlideId,
+          transitioning: true
+        })
+      },
+      afterChange: () => { this.setState({ transitioning: false }) }
     }
+
     if (props.sliderLazyLoad) {
       this.config.lazyLoad = props.sliderLazyLoad
     }
@@ -33,7 +47,7 @@ export class BaseROASlider extends Component {
   }
 
   onMouseLeave = ()  => {
-      this.slider && this.slider.slickGoTo(0, true)
+    this.slider && this.slider.slickGoTo(0, true)
   }
 
   setSlider = (element) => {
@@ -46,6 +60,11 @@ export class BaseROASlider extends Component {
 
   nextSlide = () => {
     this.slider && this.slider.slickNext()
+  }
+
+  isVisible = (currentSlideId) => {
+    if (this.state.currentSlideId === currentSlideId) { return true }
+    return this.state.transitioning
   }
 
   render() {
@@ -65,25 +84,28 @@ export class BaseROASlider extends Component {
               return (
                 <Link target={target}>
                   <InlineImage
-                  key={index}
-                  alt={image.alt}
-                  src={cloudinary.url(image.src, {
-                    transformation: 'plp_product_shot',
-                    format: 'jpg'
-                  })}
-                  lazyLoad={lazyLoad}
-                   />
+                    key={index}
+                    isVisible={this.isVisible(index)}
+                    alt={image.alt}
+                    src={cloudinary.url(image.src, {
+                      transformation: 'plp_product_shot',
+                      format: 'jpg'
+                    })}
+                    lazyLoad={lazyLoad}
+                  />
                 </Link>
               )
             } else {
               return (
                 <InlineImage
                   key={index}
+                  isVisible={this.isVisible(index)}
                   alt={image.alt}
                   src={cloudinary.url(image.src, {
                     transformation: 'plp_product_shot',
                     format: 'jpg'
-                  })} />
+                  })}
+                />
               )
             }
           })}

--- a/src/core/image/inlineImage.js
+++ b/src/core/image/inlineImage.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import Sizes from './sizes.base'
 import SourceSet from './sourceSet.base'
 
-const InlineImage = ({ alt, src, sizes: inSizes, srcSet: inSources, lazyLoad, ...props }) => {
+const InlineImage = ({ alt, src, sizes: inSizes, srcSet: inSources, lazyLoad, isVisible, ...props }) => {
     let srcSet =  undefined
     if (inSources) {
       srcSet = new SourceSet(inSources).toString()
@@ -13,6 +13,10 @@ const InlineImage = ({ alt, src, sizes: inSizes, srcSet: inSources, lazyLoad, ..
     if (inSizes) {
       sizesStr = new Sizes(inSizes).toString()
     }
+
+    let visibility = 'visible'
+    if (!isVisible) { visibility = 'hidden' }
+
     if (!lazyLoad) {
       return (
         <img
@@ -20,6 +24,7 @@ const InlineImage = ({ alt, src, sizes: inSizes, srcSet: inSources, lazyLoad, ..
           src={src}
           srcSet={srcSet}
           sizes={sizesStr}
+          style={{ visibility: visibility }}
           {...props} />
       )
     } else {
@@ -29,18 +34,21 @@ const InlineImage = ({ alt, src, sizes: inSizes, srcSet: inSources, lazyLoad, ..
           data-src={src}
           srcSet={srcSet}
           sizes={sizesStr}
+          style={{ visibility: visibility }}
           {...props} />
       )
     }
 }
 
 InlineImage.defaultProps = {
-  alt: ''
+  alt: '',
+  isVisible: true
 }
 
 InlineImage.propTypes = {
   alt: PropTypes.string.isRequired,
   lazyLoad: PropTypes.string,
+  isVisible: PropTypes.bool,
   src: PropTypes.string.isRequired,
   sizes: PropTypes.object,
   srcSet: PropTypes.oneOfType([


### PR DESCRIPTION
#### What does this PR do?

Hides noncurrent item cards on PLP.

Basically Katie's PR with very minor changes: https://github.com/rocketsofawesome/mirage/pull/140.

This was reverted in the past due to side effect, where mobile users have to tap on item twice (after sliding) to get to PDP.

This seems to already be on production, so we can fix in another ticket.

#### Relevant Tickets

- [Finishes #167408546]
  - https://www.pivotaltracker.com/n/projects/2089973/stories/167408546