### PR TITLE
[#168382171] Let mobile user tap once to navigate to PDP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.378",
+  "version": "0.1.379",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.378",
+  "version": "0.1.379",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/images/slider/slider.base.js
+++ b/src/components/images/slider/slider.base.js
@@ -32,7 +32,15 @@ export class BaseROASlider extends Component {
           transitioning: true
         })
       },
-      afterChange: () => { this.setState({ transitioning: false }) }
+      afterChange: () => {
+        this.setState({ transitioning: false })
+
+        // Let mobile user tap once (instead of twice), to navigate to PDP
+        // TODO: Wait for official fix, or move away from React Slider
+        if (this.slider && this.slider.innerSlider) {
+          this.slider.innerSlider.clickable = true
+        }
+      }
     }
 
     if (props.sliderLazyLoad) {


### PR DESCRIPTION
#### What does this PR do?

Lets mobile user tap once (instead of twice) to navigate to PDP, after sliding on PLP.

Hacky solution inspired from open issue on `react-slick`.

Have to wait for for official fix, or move away from `react-slick`.

Former won't happen anytime soon!

#### Relevant Tickets

- [Finishes #168382171]
  - https://www.pivotaltracker.com/n/projects/2089973/stories/168382171