### PR TITLE
[#168383382] Make color picker use custom swatch if provided

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.384",
+  "version": "0.1.385",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.384",
+  "version": "0.1.385",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/productTile/colorPicker/colorsInterface.base.js
+++ b/src/modules/productTile/colorPicker/colorsInterface.base.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import cloudinary from 'SRC/services/cloudinary'
 import { ColorPicker, Desktop, Default, P } from 'SRC'
+import { swatchUrl } from 'SRC'
 
 const ColorsInterface = ({ className, colorways, productId, onChange, selected }) => {
   if (colorways && colorways.length > 1) {
@@ -14,12 +14,10 @@ const ColorsInterface = ({ className, colorways, productId, onChange, selected }
         <Desktop display='flex' >
           <P>Colors</P>
           {colorways.map((colorway) => {
-            const src = cloudinary.url(colorway.shots[0].cloudinary_key,{
-              transformation: 'swatch_v2',
+            const src = swatchUrl(colorway, {
               crop: 'scale',
               quality: 100,
-              width: 40,
-              format: 'jpg'
+              width: 40
             })
             const input = {
               value: colorway.code,

--- a/src/modules/productTile/colorPicker/defaultProps.js
+++ b/src/modules/productTile/colorPicker/defaultProps.js
@@ -21,6 +21,7 @@ export const colorways = [
           "cloudinary_key": "production/catalog/wpnzyaxvwis3wfrb3xpb"
         }
       ],
+      "swatch_cloudinary_key": null,
       "skus": [
         {
           "id": 19579,
@@ -105,6 +106,7 @@ export const colorways = [
           "cloudinary_key": "production/catalog/lyvrgfbajuuwq2w6jfxu"
         }
       ],
+      "swatch_cloudinary_key": null,
       "skus": [
         {
           "id": 19587,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,4 @@
 export * from './pricing'
 export { default as withSortedSizes } from './variantSizeSorter'
 export * from './shotSorter'
+export * from './swatchUrl'

--- a/src/utils/swatchUrl.js
+++ b/src/utils/swatchUrl.js
@@ -1,0 +1,20 @@
+import cloudinary from 'SRC/services/cloudinary'
+
+export const swatchUrl = (colorway, overrides = {}) => {
+  let shot = colorway.shots.find((s) => {
+      return s.shot_type === 'front'
+    })
+  if (!shot) {
+    // Fall back to whatever is available if front shot is missing
+    shot = colorway.shots[0]
+  }
+
+  const url = colorway.swatch_cloudinary_key || shot.cloudinary_key
+  let defaults = { format: 'jpg' }
+
+  if (!colorway.swatch_cloudinary_key) {
+    defaults.transformation = 'swatch_v2'
+  }
+
+  return cloudinary.url(url, { ...defaults, ...overrides })
+}

--- a/src/utils/swatchUrl.test.js
+++ b/src/utils/swatchUrl.test.js
@@ -1,0 +1,39 @@
+import { swatchUrl } from 'SRC'
+
+describe('(Util) swatchUrl', () => {
+  describe('when a custom swatch has been provided', () => {
+    test('returns a cloudinary url for the custom swatch', () => {
+      const colorway = buildColorway({
+        swatch_cloudinary_key: 'test/custom_swatch'
+      })
+
+      const url = swatchUrl(colorway)
+
+      expect(url).toMatch(/test\/custom_swatch.jpg$/)
+    })
+  })
+
+  describe('when a custom swatch has not been provided', () => {
+    test('returns a cloudinary url for the default swatch', () => {
+      const colorway = buildColorway({
+        swatch_cloudinary_key: null
+      })
+
+      const url = swatchUrl(colorway)
+
+      expect(url).toMatch(/test\/front.jpg$/)
+      expect(url).toMatch(/t_swatch_v2/)
+    })
+  })
+})
+
+function buildColorway(overrides = {}) {
+  return {
+    shots: [
+      { shot_type: 'back', cloudinary_key: 'test/back' },
+      { shot_type: 'front', cloudinary_key: 'test/front' }
+    ],
+    swatch_cloudinary_key: null,
+    ...overrides
+  }
+}


### PR DESCRIPTION
#### What does this PR do?

Create helper function `swatchUrl` to get the color swatch URL from Cloudinary.
`swatchUrl` will check for the presence of a custom swatch for the given colorway before using the default transformation on the 'front' shot.

#### PR Dependencies

Requires commits in Canon, Quark, and Thor to complete the story.

#### Relevant Tickets

- [Finishes #168383382] 
  - https://www.pivotaltracker.com/story/show/168383382

