### PR TITLE
[#168468228] Permit styled H1 to receive letterSpacing prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.385",
+  "version": "0.1.386",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.385",
+  "version": "0.1.386",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/core/typography/H1.js
+++ b/src/core/typography/H1.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 const H1 = styled.h1`
   ${props => props.center ? 'text-align: center;' : ''}
-  letter-spacing: .1rem;
+  letter-spacing: ${props => props.letterSpacing};
   text-transform: ${props => props.lowercase
     ? 'inherit' : 'uppercase'};
 
@@ -23,6 +23,16 @@ const H1 = styled.h1`
 `
 
 H1.propTypes = {
+  letterSpacing: PropTypes.string,
+  fontSizes: PropTypes.shape({
+    desktop: PropTypes.string,
+    mobile: PropTypes.string
+  }),
+  lineHeights: PropTypes.shape({
+    desktop: PropTypes.number,
+    mobile: PropTypes.number
+  }),
+  margin: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.array,
     PropTypes.string,
@@ -40,15 +50,16 @@ H1.propTypes = {
 }
 
 H1.defaultProps = {
+  letterSpacing: '.1rem',
   fontSizes: {
     desktop: '4.2rem',
     mobile: '3.2rem'
   },
-  margin: '5.5rem 0',
   lineHeights: {
     desktop: 1.0476190476190477,
     mobile: 1.3
-  }
+  },
+  margin: '5.5rem 0'
 }
 
 export default H1

--- a/src/core/typography/H1.test.js
+++ b/src/core/typography/H1.test.js
@@ -16,23 +16,48 @@ describe('(Styled Component) H1', () => {
   })
 
   test('setting lowercase prop', () => {
-    expect(createH1({lowercase: true}))
-    .toHaveStyleRule({
-      'text-transform': 'inherit'
-    })
+    expect(createH1({ lowercase: true }))
+    .toHaveStyleRule(
+      'text-transform', 'inherit'
+    )
   })
 
   test('setting center prop', () => {
-    expect(createH1({center: true}))
-    .toHaveStyleRule({
-      'text-align': 'center'
-    })
+    expect(createH1({ center: true }))
+    .toHaveStyleRule(
+      'text-align', 'center'
+    )
   })
 
   test('center prop not set', () => {
-    expect(createH1({center: false}))
-    .toHaveStyleRule({
-      'text-align': undefined
-    })
+    expect(createH1({ center: false }))
+    .toHaveStyleRule(
+      'text-align', undefined
+    )
+  })
+
+  test('setting letter spacing prop', () => {
+    expect(createH1({ letterSpacing: '0.05rem' }))
+    .toHaveStyleRule(
+      'letter-spacing', '0.05rem'
+    )
+  })
+
+  test('setting fontSizes prop', () => {
+    expect(createH1({ fontSizes: { desktop: '3.2rem', mobile: '2.4rem' } }))
+    .toHaveStyleRule(
+      'font-size', '3.2rem', {
+        media: '(min-width: 768px)'
+      }
+    )
+  })
+
+  test('setting lineHeights prop', () => {
+    expect(createH1({ lineHeights: { desktop: 2, mobile: 1.5 } }))
+    .toHaveStyleRule(
+      'line-height', `${2}`, {
+        media: '(min-width: 768px)'
+      }
+    )
   })
 })

--- a/src/core/typography/__snapshots__/H1.test.js.snap
+++ b/src/core/typography/__snapshots__/H1.test.js.snap
@@ -29,5 +29,6 @@ exports[`(Styled Component) H1 matching the snapshot 1`] = `
 
 <h1
   className="c0"
+  letterSpacing=".1rem"
 />
 `;


### PR DESCRIPTION
#### What does this PR do?

Permits styled H1 component to receive `letterSpacing` prop.
This change will allow us to style the H1 in Thor to match the styling of an H2.

#### PR Dependencies

Depends on PR in Thor.

#### Relevant Tickets

- [Finishes #168468228]
  - https://www.pivotaltracker.com/story/show/168468228
