### PR TITLE
Use callback refs to ensure backwards compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.391",
+  "version": "0.1.392",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.391",
+  "version": "0.1.392",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/confetti/Confetti.js
+++ b/src/components/confetti/Confetti.js
@@ -67,12 +67,17 @@ const colorOptions = [
 class Confetti extends React.Component {
   constructor(props) {
     super(props)
-    this.canvasRef = React.createRef()
+    this.setCanvasRef = this.setCanvasRef.bind(this)
     this.animate = this.animate.bind(this)
+    this.setup = this.setup.bind(this)
   }
 
   componentDidMount() {
-    setTimeout(this.setup.bind(this), 500)
+    setTimeout(this.setup, 500)
+  }
+
+  setCanvasRef(canvas) {
+    this.canvas = canvas
   }
 
   componentWillUnmount() {
@@ -102,8 +107,7 @@ class Confetti extends React.Component {
   }
 
   getContext() {
-    const canvas = this.canvasRef.current
-    return canvas.getContext('2d')
+    return this.canvas.getContext('2d')
   }
 
   animate() {
@@ -130,7 +134,7 @@ class Confetti extends React.Component {
   render() {
     const { width, height } = this.props
     return (
-      <canvas ref={this.canvasRef} width={width} height={height}></canvas>
+      <canvas ref={this.setCanvasRef} width={width} height={height}></canvas>
     )
   }
 }


### PR DESCRIPTION
#### What does this PR do?
With this change we'll update how we set refs on the `Confetti` component so we ensure backwards compatibility with React 15 used by quark-ui.