### PR TITLE
Allow customers to select gift options at checkout

### DIFF
--- a/src/components/paymentRequestForm/paymentRequestForm.js
+++ b/src/components/paymentRequestForm/paymentRequestForm.js
@@ -1,7 +1,9 @@
 import React from 'react'
+import styled from 'styled-components'
 import PropTypes from 'prop-types'
-
 import { PaymentRequestButtonElement, injectStripe } from 'react-stripe-elements'
+
+import { P } from 'SRC'
 
 const buildDisplayItems = (order, pending) => {
   let displayItems = [
@@ -28,6 +30,11 @@ const buildDisplayItems = (order, pending) => {
 
   return displayItems
 }
+
+const OrContainer = styled(P)`
+  margin: 0 10px;
+`
+
 export class PaymentRequestForm extends React.Component {
   constructor (props) {
     super(props)
@@ -126,21 +133,28 @@ export class PaymentRequestForm extends React.Component {
   }
 
   render () {
-    return this.state.canMakePayment ? (
-      <PaymentRequestButtonElement
-        paymentRequest={this.state.paymentRequest}
-        className={this.props.className}
-        onClick={this.props.onClickPaymentRequestButton}
-        style={{
-          // For more details on how to style the Payment Request Button, see:
-          // https://stripe.com/docs/elements/payment-request-button#styling-the-element
-          paymentRequestButton: {
-            theme: 'dark',
-            height: '50px'
-          }
-        }}
-      />
-    ) : null
+    if (!this.state.canMakePayment) {
+      return null
+    }
+
+    return (
+      <React.Fragment>
+        <OrContainer>OR</OrContainer>
+        <PaymentRequestButtonElement
+          paymentRequest={this.state.paymentRequest}
+          className={this.props.className}
+          onClick={this.props.onClickPaymentRequestButton}
+          style={{
+            // For more details on how to style the Payment Request Button, see:
+            // https://stripe.com/docs/elements/payment-request-button#styling-the-element
+            paymentRequestButton: {
+              theme: 'dark',
+              height: '50px'
+            }
+          }}
+        />
+      </React.Fragment>
+    )
   }
 }
 

--- a/src/modules/persistent-cart/cartSidebar/cartSidebar.js
+++ b/src/modules/persistent-cart/cartSidebar/cartSidebar.js
@@ -7,7 +7,7 @@ import accounting from 'accounting'
 import {
   P, H3, H4, ButtonLink, ProgressBar, ProgressBarText,
   PersistentCartProductList, XIcon, PaymentRequestForm,
-  CouponCodeWrapper, EmptyCart
+  CouponCodeWrapper, EmptyCart, NavyLink
 } from 'SRC'
 
 const Overlay = styled.div`
@@ -122,10 +122,8 @@ const Em = styled.em`
 
 const PaymentRequestButton = styled(PaymentRequestForm)`
   width: 100%;
-  max-width: 30rem;
-  margin: 0 auto;
-  margin-bottom: 20px;
 `
+
 const CheckoutLink = styled(({ renderLink, children, ...props }) => {
   if (renderLink) {
     return renderLink({...props, children: children})
@@ -150,7 +148,7 @@ const Striked = styled.span`
   margin-right: 5px;
 `
 
-const FreeShippingContainer = styled.div`
+const Padding = styled.div`
   padding-top: 10px;
 `
 
@@ -170,6 +168,13 @@ const OrderTotal = ({ order }) => {
     </Total>
   )
 }
+
+const CheckoutButtonsContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+`
 
 class BaseCartSidebar extends React.Component {
   constructor (props) {
@@ -284,28 +289,38 @@ class BaseCartSidebar extends React.Component {
               showBorder={false}
             />
             <OrderTotal order={order} />
-            {parseFloat(order.total) > 0 && <Elements>
-              <PaymentRequestButton
-                currentUserEmail={currentUserEmail}
-                order={order}
-                setShippingAddress={setShippingAddress}
-                submitCheckout={this.submitCheckout}
-                onClickPaymentRequestButton={onClickPaymentRequestButton}
-              />
-            </Elements>}
-            <ButtonLink
-              renderLink={renderLink}
-              target='/checkout'
-              width='100%'
-              maxWidth='30rem'
-              kind='blue'
-              disabled={isCheckoutButtonDisabled}
-              onClick={onClickCheckout}>
-              CHECKOUT
-            </ButtonLink>
-            <FreeShippingContainer>
+
+            <CheckoutButtonsContainer>
+              <ButtonLink
+                renderLink={renderLink}
+                target='/checkout'
+                width='100%'
+                maxWidth='30rem'
+                kind='blue'
+                disabled={isCheckoutButtonDisabled}
+                onClick={onClickCheckout}>
+                CHECKOUT
+              </ButtonLink>
+              {parseFloat(order.total) > 0 && <Elements>
+                <PaymentRequestButton
+                  currentUserEmail={currentUserEmail}
+                  order={order}
+                  setShippingAddress={setShippingAddress}
+                  submitCheckout={this.submitCheckout}
+                  onClickPaymentRequestButton={onClickPaymentRequestButton}
+                />
+              </Elements>}
+            </CheckoutButtonsContainer>
+
+            <Padding>
+              <NavyLink target='/checkout' renderLink={renderLink}>
+                Is this a gift?
+              </NavyLink>
+            </Padding>
+
+            <Padding>
               <P fontSize='14px'>Free shipping on orders of $50+</P>
-            </FreeShippingContainer>
+            </Padding>
           </Footer>
         </CartSidebarContainer>
       </div>

--- a/src/modules/persistent-cart/cartSidebar/cartSidebar.md
+++ b/src/modules/persistent-cart/cartSidebar/cartSidebar.md
@@ -1,10 +1,10 @@
-<!-- ```js
+```js
   <StripeProviderWrapper>
     <CartSidebar
       shouldShowCartSidebar={true}
       hideCartSidebar={() => {}}
       submitBag={() => { console.log('submit bag') }}
-      subTotal={"22.5"}
+      subTotal={22.5}
       itemsInBag={4}
       order={{
         applied_coupon_codes: [],
@@ -48,4 +48,4 @@
     />
   </StripeProviderWrapper>
 ```
- -->
+


### PR DESCRIPTION
#### What does this PR do?
With this change we'll display the Is this a gift? link on the cart sidebar so customers know we have gifting options through our traditional checkout.

This change will also re-arrange our checkout buttons so they are displayed inline.

#### Screenshots
<img width="341" alt="Screen Shot 2019-10-10 at 12 31 41 PM" src="https://user-images.githubusercontent.com/1505446/66592099-fe258800-eb59-11e9-96f1-48f01ae3111f.png">

#### Relevant tickets
https://www.pivotaltracker.com/story/show/168985573
