### PR TITLE
[#169260976] Call hideCartSidebar on product click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.392",
+  "version": "0.1.393",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.392",
+  "version": "0.1.393",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.js
+++ b/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.js
@@ -144,8 +144,8 @@ class BaseProduct extends React.Component {
     return (
       <div className={className}>
         <Thumbnail>
-          <ImageLink renderLink={renderLink} target={`/products/${item.slug}-${item.colorway_slug}`} onClick={hideCartSidebar}>
-            <img alt={item.description} src={this._getVariantShot()} />
+          <ImageLink renderLink={renderLink} target={`/products/${item.slug}-${item.colorway_slug}`}>
+            <img alt={item.description} src={this._getVariantShot()} onClick={hideCartSidebar} />
           </ImageLink>
         </Thumbnail>
         <div>


### PR DESCRIPTION
#### What does this PR do?

Calls `hideCartSidebar` on product click.

Moves `hideCartSidebar` from `ImageLink` level to `img` level.

#### Relevant Tickets

- [#169260976]
  - https://www.pivotaltracker.com/n/projects/2089973/stories/169260976