### PR TITLE
[ch5617] Add query params to GiftLink

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.399",
+  "version": "0.1.400",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.399",
+  "version": "0.1.400",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/persistent-cart/cartSidebar/cartSidebar.js
+++ b/src/modules/persistent-cart/cartSidebar/cartSidebar.js
@@ -330,7 +330,7 @@ class BaseCartSidebar extends React.Component {
             </CheckoutButtonsContainer>
             { giftFeatureOn &&
               <Padding>
-                <GiftLink target='/checkout' renderLink={renderLink}>
+                <GiftLink target='/checkout?contains_gift=true' renderLink={renderLink}>
                   Is this a gift?
                 </GiftLink>
               </Padding>


### PR DESCRIPTION
#### What does this PR do?

Adds query param indicating order is a gift when customer clicks on "Is this a gift?" in the cart.

#### PR Dependencies

Dependent on PRs in Quark UI and Thor and changes made to `/checkout` in Quark UI to start with gift option checked.

#### Relevant Tickets

[ch5617]
