### PR TITLE
[#168811273] Display original price next to sale price on PLP product tiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.400",
+  "version": "0.1.401",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.400",
+  "version": "0.1.401",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/productTile/index.js
+++ b/src/modules/productTile/index.js
@@ -1,3 +1,4 @@
 export { default as ProductTile } from './productTile'
 export * from './colorPicker'
 export * from './quickAdd'
+export * from './productPrice'

--- a/src/modules/productTile/productPrice/index.js
+++ b/src/modules/productTile/productPrice/index.js
@@ -1,0 +1,1 @@
+export { default as ProductPrice } from './productPrice'

--- a/src/modules/productTile/productPrice/productPrice.js
+++ b/src/modules/productTile/productPrice/productPrice.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { P, formatPrice } from 'SRC'
+
+
+const BaseProductPrice = ({ colorway, className }) => {
+  const formatSalePrice = (price) => {
+    const decimalPlaces = parseInt(price, 10) === parseFloat(price) ? 0 : 2
+    return formatPrice(price, "$", decimalPlaces)
+  }
+
+  const originalPrice = colorway.skus[0].original_price
+  const price = colorway.skus[0].price
+  const onSale = originalPrice && originalPrice !== 0 && price < originalPrice
+
+  if (onSale) {
+    return(
+      <P className={className}>
+        {formatSalePrice(price)}
+        <span className="original-price">({formatPrice(originalPrice)} reg)</span>
+      </P>
+    )
+  } else {
+    return(
+      <P>{formatPrice(price)}</P>
+    )
+  }
+}
+
+const ProductPrice = styled(BaseProductPrice)`
+  font-weight: 500;
+  font-size: 1.65rem;
+
+  .original-price {
+    font-weight: normal;
+    font-size: 1.6rem;
+    color: #6d7278;
+    margin-left: 8px;
+  }
+`
+
+BaseProductPrice.propTypes = {
+  colorway: PropTypes.object,
+  className: PropTypes.string
+}
+
+/** @component */
+export default ProductPrice

--- a/src/modules/productTile/productPrice/productPrice.test.js
+++ b/src/modules/productTile/productPrice/productPrice.test.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import { css } from 'styled-components'
+import 'jest-styled-components'
+
+import { P, formatPrice } from 'SRC'
+import ProductPrice from './productPrice'
+
+const { mountWithTheme } = global
+
+const saleProps = {
+  "colorway": {
+    "skus": [
+      {
+        "price": 8.0,
+        "original_price": 22.5
+      }
+    ]
+  }
+}
+
+const noSaleProps = {
+  "colorway": {
+    "skus": [
+      {
+        "price": 22.5,
+        "original_price": 22.5
+      }
+    ]
+  }
+}
+
+
+describe('(Styled Component) ProductPrice', () => {
+  test('renders original price when there is a sale', () => {
+    let component = mountWithTheme(<ProductPrice {...saleProps} />)
+
+    expect(
+     component
+      .find(P)
+      .first()
+      .text()
+    ).toContain(formatPrice(saleProps.colorway.skus[0].original_price))
+  })
+
+  test('does not render original price when there is not a sale', () => {
+    let component = mountWithTheme(<ProductPrice {...noSaleProps} />)
+
+    expect(
+     component
+      .find(P)
+      .first()
+      .text()
+    ).not.toContain(`(${formatPrice(noSaleProps.colorway.skus[0].original_price)} reg)`)
+  })
+
+  test('renders price when there is not a sale', () => {
+    let component = mountWithTheme(<ProductPrice {...noSaleProps} />)
+
+    expect(
+     component
+      .find(P)
+      .first()
+      .text()
+    ).toContain(formatPrice(noSaleProps.colorway.skus[0].price))
+  })
+})

--- a/src/modules/productTile/productTile.base.js
+++ b/src/modules/productTile/productTile.base.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { ColorsInterface, P, ROASlider, QuickAdd, formatPrice } from 'SRC'
+import { ColorsInterface, P, ROASlider, QuickAdd, ProductPrice } from 'SRC'
 
 import { default as withSortedShots } from 'SRC/utils/shotSorter'
 
@@ -69,14 +69,14 @@ export default class ProductTile extends React.Component {
         </QuickAdd>
         { (renderLink && target) ?
           <Link
-            className='roa-prodiuct-tile-details'
+            className='roa-product-tile-details'
             target={target}>
             <P>{product.name}</P>
-            <P>{formatPrice(colorway.skus[0].price)}</P>
+            <ProductPrice colorway={colorway} />
           </Link> :
-          <div className='roa-prodiuct-tile-details'>
+          <div className='roa-product-tile-details'>
             <P>{product.name}</P>
-            <P>{formatPrice(colorway.skus[0].price)}</P>
+            <ProductPrice colorway={colorway} />
           </div>
         }
         <ColorsInterface

--- a/src/modules/productTile/productTile.js
+++ b/src/modules/productTile/productTile.js
@@ -15,13 +15,13 @@ const ProductTile = styled(BaseProductTile)`
     display: flex;
     flex: 1 1 100%;
   }
-  .roa-prodiuct-tile-details {
+  .roa-product-tile-details {
     display: flex;
     flex-wrap: wrap;
     flex: 1 1 100%;
     text-decoration: none;
   }
-  .roa-prodiuct-tile-details ${P} {
+  .roa-product-tile-details ${P} {
     flex: 1 1 100%;
     &:first-of-type {
       margin-top: 1.7rem;

--- a/src/utils/pricing.js
+++ b/src/utils/pricing.js
@@ -1,5 +1,5 @@
 import accounting from 'accounting'
 
-export const formatPrice = (value = 0) => {
-  return accounting.formatMoney(value)
+export const formatPrice = (value = 0, ...options) => {
+  return accounting.formatMoney(value, ...options)
 }


### PR DESCRIPTION
#### What does this PR do?

Displays original price next to sale price on PLP product tiles

#### Screenshots

![Screen Shot 2019-11-06 at 6 06 38 PM](https://user-images.githubusercontent.com/43832282/68345797-4041db00-00c0-11ea-907e-2300dd6b6534.png)

#### PR Dependencies

PR on Thor

#### Relevant Tickets

- [#168811273]
  - https://www.pivotaltracker.com/story/show/168811273
