### PR TITLE
[ch5975] Remove FINAL SALE copy from gifting modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.414",
+  "version": "0.1.415",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.414",
+  "version": "0.1.415",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/giftModal/GiftModal.js
+++ b/src/components/giftModal/GiftModal.js
@@ -28,11 +28,6 @@ const Text = styled(P)`
   margin-bottom: 15px;
 `
 
-const FinalSaleText = styled(P)`
-  font-size: 1.4rem;
-  margin-top: 27px;
-`
-
 const Image = styled(InlineImage)`
   max-width: 100%;
   margin-bottom: 15px;
@@ -62,9 +57,6 @@ const GiftModal = ({ onClose }) => (
     <Text>
       And don’t forget, buy 4+ items to get 20% off your order!
     </Text>
-    <FinalSaleText>
-      *Excludes FINAL SALE
-    </FinalSaleText>
   </Container>
 )
 


### PR DESCRIPTION
#### What does this PR do?

Removes FINAL SALE copy from gifting modal.

Updates Mirage to `0.1.415`.

#### Relevant Tickets

- [ch5975]
  - https://app.clubhouse.io/rockets/story/5975/customer-reading-gifting-promotional-pop-up-doesn-t-see-final-sale-language