### PR TITLE
[ch5975] Remove asterisk from gifting modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.415",
+  "version": "0.1.416",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.415",
+  "version": "0.1.416",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/giftModal/GiftModal.js
+++ b/src/components/giftModal/GiftModal.js
@@ -52,7 +52,7 @@ const GiftModal = ({ onClose }) => (
     <Text>
       At checkout, leave a message that will show on the packing
       slip without pricing. Need an exchange?
-      It’s free and easy via our friendly customer service team.*
+      It’s free and easy via our friendly customer service team.
     </Text>
     <Text>
       And don’t forget, buy 4+ items to get 20% off your order!


### PR DESCRIPTION
#### What does this PR do?

Removes asterisk from gifting modal.

Updates `@rocketsofawesome/mirage` to `0.1.416`.

#### Relevant Tickets

- [ch5975]
  - https://app.clubhouse.io/rockets/story/5975/customer-reading-gifting-promotional-pop-up-doesn-t-see-final-sale-language