### PR TITLE
Display the evergreen promotional price on ProductTiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.417",
+  "version": "0.1.418",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.417",
+  "version": "0.1.418",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/persistent-cart/cartSidebar/cartSidebar.md
+++ b/src/modules/persistent-cart/cartSidebar/cartSidebar.md
@@ -36,7 +36,6 @@
       updateBag={() => { console.log('update bag') }}
       removeItem={() => { console.log('remove item') }}
       segmentCartViewed={() => { console.log('segment cart viewed') }}
-      pricingTestOn={true}
       promotion={null}
       promotionLoading={false}
       promoHasBeenApplied={null}

--- a/src/modules/productTile/colorPicker/colorsInterface.js
+++ b/src/modules/productTile/colorPicker/colorsInterface.js
@@ -15,11 +15,11 @@ const ColorsInterface = ({ className, colorways, productId, onChange, selected }
     return (
       <div className={className}>
         <Default displayTarget='belowTabletMax'>
-          <P>{colorways.length} colors available</P>
+          <P fontSize="14px">{colorways.length} colors available</P>
         </Default>
         <Desktop>
           <SwatchContainer>
-            <P>Colors</P>
+            <P fontSize="14px">Colors</P>
             {colorways.map((colorway) => {
               const src = swatchUrl(colorway, {
                 crop: 'scale',

--- a/src/modules/productTile/defaultProps.js
+++ b/src/modules/productTile/defaultProps.js
@@ -1,6 +1,136 @@
 const exampleClickHandler = (sku) => () => { alert(`${sku} clicked`) }
+const productOnSale = {
+  product: {
+    "_index": "colorways_development_20190706143737041",
+    "_type": "colorway",
+    "_id": "4312",
+    "_score": null,
+    "sort": [
+      5860003
+    ],
+    "color_family": "blue",
+    "color": "Blue",
+    "nav_taxons": [
+      "shop/boys-new-arrivals",
+      "shop/boys-new-arrivals/swim",
+      "featured-products/summer-2019",
+      "shop/boys",
+      "shop/boys/swimwear",
+      "shop/vacation"
+    ],
+    "nav_categories": [
+      "Boys New Arrivals",
+      "Swim",
+      "Boys",
+      "Swimwear"
+    ],
+    "skus": [
+      {
+        "size": [
+          "OS"
+        ],
+        "in_stock": true
+      }
+    ],
+    "code": "A222-C01",
+    "category": [
+      "Swim",
+      "Swim Accessories"
+    ],
+    "description": "AHHHHHHH! The coolest goggles on the planet are here.",
+    "details": "*90% silicone, 10% pc\r\n*UV protected & anti-fog lenses\r\n*Adjustable head strap",
+    "id": "1665-A222-C01",
+    "product_id": 1665,
+    "product_slug": "monster-goggle",
+    "colorway_id": 4312,
+    "name": "Monster Goggle",
+    "sort_order": [
+      {
+        "shop": 230023
+      },
+      {
+        "shop-boys": 230023
+      },
+      {
+        "shop-boys-swimwear": 230023
+      },
+      {
+        "shop": 2350008
+      },
+      {
+        "shop-boys-new-arrivals": 2350008
+      },
+      {
+        "shop-boys-new-arrivals-swim": 2350008
+      },
+      {
+        "featured-products": 5860003
+      },
+      {
+        "featured-products-summer-2019": 5860003
+      },
+      {
+        "shop": 2780049
+      },
+      {
+        "shop-vacation": 2780049
+      }
+    ],
+    "style_number": "A222",
+    "colorways": [
+      {
+        "id": 4312,
+        "slug": "blue",
+        "color": "Blue",
+        "code": "A222-C01",
+        "shots": [
+          {
+            "id": 2707248,
+            "shot_type": "front",
+            "cloudinary_key": "production/catalog/uduxsics6nhvmvilwh16"
+          }
+        ],
+        "skus": [
+          {
+            "id": 18009,
+            "sku": "A222-C01-A",
+            "size": "OS",
+            "price": 10.0,
+            "original_price": 24.5,
+            "cost_price": null,
+            "in_stock": true
+          }
+        ]
+      },
+      {
+        "id": 4311,
+        "slug": "moss",
+        "color": "Moss",
+        "code": "A222-D07",
+        "shots": [
+          {
+            "id": 2707247,
+            "shot_type": "front",
+            "cloudinary_key": "production/catalog/dyv8xevmgetyztwk3ald"
+          }
+        ],
+        "skus": [
+          {
+            "id": 18008,
+            "sku": "A222-D07-A",
+            "size": "OS",
+            "price": 24.5,
+            "cost_price": null,
+            "in_stock": true
+          }
+        ]
+      }
+    ]
+  },
+  quickAdd: exampleClickHandler
+}
 const productWithVariants = {
-  product:   {
+  product: {
     "_index": "colorways_production_20190708213725142",
     "_type": "colorway",
     "_id": "4484",
@@ -452,4 +582,4 @@ const productWithOneSize = {
   quickAdd: exampleClickHandler
 }
 
-export { productWithVariants, productWithOneSize }
+export { productWithVariants, productWithOneSize, productOnSale }

--- a/src/modules/productTile/productPrice/productPrice.js
+++ b/src/modules/productTile/productPrice/productPrice.js
@@ -1,40 +1,46 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { P, formatPrice } from 'SRC'
+import { P, formatPrice, theme } from 'SRC'
 
+const Text = styled(P)`
+  font-weight: 500;
+  font-size: 14px;
+`;
+
+const formatSalePrice = (price) => {
+  const decimalPlaces = parseInt(price, 10) === parseFloat(price) ? 0 : 2
+  return formatPrice(price, "$", decimalPlaces)
+}
 
 const BaseProductPrice = ({ colorway, className }) => {
-  const formatSalePrice = (price) => {
-    const decimalPlaces = parseInt(price, 10) === parseFloat(price) ? 0 : 2
-    return formatPrice(price, "$", decimalPlaces)
-  }
-
   const originalPrice = colorway.skus[0].original_price
   const price = colorway.skus[0].price
   const onSale = originalPrice && originalPrice !== 0 && price < originalPrice
+  const promoPrice = parseFloat(price) * 0.8
+
+  let pricingLine = <Text>{formatPrice(price)}</Text>
 
   if (onSale) {
-    return(
-      <P className={className}>
+    pricingLine = (
+      <Text>
         {formatSalePrice(price)}
         <span className="original-price">({formatPrice(originalPrice)} reg)</span>
-      </P>
-    )
-  } else {
-    return(
-      <P>{formatPrice(price)}</P>
+      </Text>
     )
   }
+
+  return (
+    <div className={className}>
+      {pricingLine}
+      <Text color={theme.colors.rocketBlue}>{formatPrice(promoPrice)} with 4+ items</Text>
+    </div>
+  )
 }
 
 const ProductPrice = styled(BaseProductPrice)`
-  font-weight: 500;
-  font-size: 1.65rem;
-
   .original-price {
     font-weight: normal;
-    font-size: 1.6rem;
     color: #6d7278;
     margin-left: 8px;
   }

--- a/src/modules/productTile/productTile.base.js
+++ b/src/modules/productTile/productTile.base.js
@@ -71,11 +71,11 @@ export default class ProductTile extends React.Component {
           <Link
             className='roa-product-tile-details'
             target={target}>
-            <P>{product.name}</P>
+            <P fontSize="14px">{product.name}</P>
             <ProductPrice colorway={colorway} />
           </Link> :
           <div className='roa-product-tile-details'>
-            <P>{product.name}</P>
+            <P fontSize="14px">{product.name}</P>
             <ProductPrice colorway={colorway} />
           </div>
         }

--- a/src/modules/productTile/productTile.js
+++ b/src/modules/productTile/productTile.js
@@ -20,12 +20,10 @@ const ProductTile = styled(BaseProductTile)`
     flex-wrap: wrap;
     flex: 1 1 100%;
     text-decoration: none;
+    padding-top: 1.7rem;
   }
   .roa-product-tile-details ${P} {
     flex: 1 1 100%;
-    &:first-of-type {
-      margin-top: 1.7rem;
-    }
   }
 `
 

--- a/src/modules/productTile/productTile.md
+++ b/src/modules/productTile/productTile.md
@@ -12,3 +12,11 @@
     <ProductTile {...require('./defaultProps').productWithOneSize} />
   </div>
 ```
+
+
+#### Product Tile for a product in Sale
+```js
+  <div style={{ width: '33.33%'}}>
+    <ProductTile {...require('./defaultProps').productOnSale} />
+  </div>
+```


### PR DESCRIPTION
#### What does this PR do?
With this change we'll start displaying the evergreen promotional price inside product tiles, hopefully this will prompt users to add more items to their cart.

#### Screenshots
<img width="343" alt="Screen Shot 2019-12-13 at 6 36 17 PM" src="https://user-images.githubusercontent.com/1505446/70840391-8a149400-1dd7-11ea-8e8c-31b3bc36632b.png">

#### Relevant Tickets
https://app.clubhouse.io/rockets/story/5898/customer-can-see-price-of-item-with-evergreen-promo-applied-on-item-cards
