### PR TITLE
[ch5968] Fix styling on InputSmall and PropTypes on XCheckbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.420",
+  "version": "0.1.421",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.420",
+  "version": "0.1.421",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/inputs/InputSmall/InputSmall.js
+++ b/src/components/inputs/InputSmall/InputSmall.js
@@ -68,7 +68,7 @@ const StyledInputSmall = styled.input`
   padding-top: 12.5px;
   padding-bottom: 8.5px;
 
-  color: ${props => props.error ? props.theme.colors.flameOrange : props.theme.colors.rocketBlue}!important;
+  color: ${props => props.error ? props.theme.colors.flameOrange : props.theme.colors.navy}!important;
   font-family: ${props => props.theme.fonts.secondaryFont};
   font-size: 16px;
 
@@ -82,8 +82,8 @@ const StyledInputSmall = styled.input`
 
   &:focus {
     outline: none;
-    border-color: ${props => props.theme.colors.rocketBlue};
-    color: ${props => props.theme.colors.rocketBlue};
+    border-color: ${props => props.theme.colors.rocketBlue} !important;
+    color: ${props => props.theme.colors.rocketBlue} !important;
   }
 `
 
@@ -98,7 +98,7 @@ const StyledInputSmallElement = styled(InputElement)`
   padding-top: 12.5px;
   padding-bottom: 8.5px;
 
-  color: ${props => props.error ? props.theme.colors.flameOrange : props.theme.colors.rocketBlue}!important;
+  color: ${props => props.error ? props.theme.colors.flameOrange : props.theme.colors.navy}!important;
   font-family: ${props => props.theme.fonts.secondaryFont};
   font-size: 16px;
 
@@ -112,8 +112,8 @@ const StyledInputSmallElement = styled(InputElement)`
 
   &:focus {
     outline: none;
-    border-color: ${props => props.theme.colors.rocketBlue};
-    color: ${props => props.theme.colors.rocketBlue};
+    border-color: ${props => props.theme.colors.rocketBlue} !important;
+    color: ${props => props.theme.colors.rocketBlue} !important;
   }
 `
 

--- a/src/components/inputs/InputSmall/InputSmall.md
+++ b/src/components/inputs/InputSmall/InputSmall.md
@@ -1,5 +1,5 @@
 ```js
-  <InputSmall placeholder={'email'} />
+  <InputSmall placeholder={'email'} errorMessage='' />
 ```
 
 ```js

--- a/src/components/inputs/XCheckbox/XCheckbox.js
+++ b/src/components/inputs/XCheckbox/XCheckbox.js
@@ -25,8 +25,7 @@ class XCheckboxBase extends React.Component {
           {...input}
         />
         <XCheckboxSVG width={width} />
-        {children}
-        {label}
+        { label ? label : children }
       </Label>
     )
   }
@@ -34,9 +33,14 @@ class XCheckboxBase extends React.Component {
 
 XCheckboxBase.propTypes = {
   className: PropTypes.string,
-  input: PropTypes.shape({
-    value: PropTypes.bool
-  }),
+  input: PropTypes.oneOfType([
+    PropTypes.shape({
+      value: PropTypes.bool.isRequired
+    }),
+    PropTypes.shape({
+      checked: PropTypes.bool.isRequired
+    })
+  ]),
   label: PropTypes.string
 }
 


### PR DESCRIPTION
#### What does this PR do?

Changes color of input text for `InputSmall`.
Adjusts `XCheckbox` PropTypes to have required props for redux form component or regular React component.

#### PR Dependencies

Update Mirage version on Thor

#### Relevant Tickets

[ch5968]
https://app.clubhouse.io/rockets/story/5968/guests-can-request-to-get-alert-when-items-are-back-in-stock
