### PR TITLE
[ch6339] Make hero with destination clickable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.423",
+  "version": "0.1.424",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.423",
+  "version": "0.1.424",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/contentful/landing/landing.js
+++ b/src/modules/contentful/landing/landing.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { ContentfulRenderer } from 'SRC'
+
 const ContentfulLandingPage = ({
   className,
   fields: {
@@ -10,7 +11,7 @@ const ContentfulLandingPage = ({
   ...props
 }) => {
   return (
-    <section style={{overflow: 'hidden'}}>
+    <section style={{ overflow: 'hidden' }}>
       {section.map((element, index) => {
         return (<ContentfulRenderer key={index} {...element} {...props} />)
       })}

--- a/src/modules/contentful/touts/contentfulSplitTout.base.js
+++ b/src/modules/contentful/touts/contentfulSplitTout.base.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import { MirageMarkdown, Link, ContentfulRenderer } from 'SRC'
 
-const BaseContentfulSplitTout =({
+const BaseContentfulSplitTout = ({
   className,
   fields: {
     description,
@@ -12,7 +12,7 @@ const BaseContentfulSplitTout =({
   renderLink,
   ...props
 }) => {
-  const links = { imageLinks: [], textLinks: []}
+  const links = { imageLinks: [], textLinks: [] }
   imageLinks.map((imageLink, index) => {
     links.imageLinks[index] =
     <ContentfulRenderer

--- a/src/modules/contentful/touts/contentfulTout.base.js
+++ b/src/modules/contentful/touts/contentfulTout.base.js
@@ -8,6 +8,25 @@ import {
 } from 'SRC'
 
 class BaseContentfulTout extends Component {
+  // If hero and destination present, navigateToDestination
+  navigateToDestination = (event) => {
+    const {
+      fields: {
+        hero,
+        destination
+      }
+    } = this.props
+
+    // Navigate on roa-tout-overlay or roa-tout-buttons click
+    // Exclude click of button itself
+    if (hero && destination && event && event.target && event.target.className &&
+      (event.target.className === 'roa-tout-overlay' ||
+      event.target.className === 'roa-tout-buttons')) {
+
+      window.location.href = destination
+    }
+  }
+
   renderContent = () => {
     const {
       displayTitle,
@@ -63,7 +82,7 @@ class BaseContentfulTout extends Component {
     } else {
       return (
         <ContentfulRenderer {...media}>
-          <div className='roa-tout-overlay'>
+          <div className='roa-tout-overlay' onClick={this.navigateToDestination}>
             <MirageMarkdown>{description}</MirageMarkdown>
             <div className='roa-tout-buttons'>
               {heroButtons && heroButtons.map((button) => {
@@ -83,13 +102,15 @@ class BaseContentfulTout extends Component {
       className,
       renderToutLink,
       fields: {
+        hero,
         destination
       }
     } = this.props
 
     const ToutLink = renderToutLink
 
-    if (destination) {
+    // If hero with destination, maintain default div layout
+    if (!hero && destination) {
       return (
         <ToutLink className={className} destination={destination}>
           {this.renderContent()}

--- a/src/modules/contentful/touts/contentfulTout.js
+++ b/src/modules/contentful/touts/contentfulTout.js
@@ -88,6 +88,13 @@ const ContentfulTout = styled(BaseContentfulTout)`
     width: 100%;
     background-color: ${props => setBackgroundColor(props)};
     ${props => textPosition(props)}
+
+    ${props => props.fields.hero && props.fields.destination && props.theme.breakpointsVerbose.belowTablet`
+      cursor: pointer;
+    `}
+    ${props => props.fields.hero && props.fields.destination && props.theme.breakpointsVerbose.aboveTablet`
+      cursor: pointer;
+    `}
   }
 
   ${MirageMarkdown} {


### PR DESCRIPTION
#### What does this PR do?

Makes `hero` with `destination` clickable.

Navigates programmatically (without `a` element): `window.location.href = destination`.

Maintains default `div` layout if `destination` present on `hero`, instead of replacing with `a` element. (The latter breaks styling.)

#### Relevant Tickets

- [ch6339]
  - https://app.clubhouse.io/rockets/story/6339/ability-for-customer-to-click-on-homepage-hero-image