### PR TITLE
Add segmentHeroClicked to BaseContentfulTout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.424",
+  "version": "0.1.425",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.424",
+  "version": "0.1.425",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/contentful/touts/contentfulTout.base.js
+++ b/src/modules/contentful/touts/contentfulTout.base.js
@@ -11,6 +11,7 @@ class BaseContentfulTout extends Component {
   // If hero and destination present, navigateToDestination
   navigateToDestination = (event) => {
     const {
+      segmentHeroClicked,
       fields: {
         hero,
         destination
@@ -23,6 +24,7 @@ class BaseContentfulTout extends Component {
       (event.target.className === 'roa-tout-overlay' ||
       event.target.className === 'roa-tout-buttons')) {
 
+      segmentHeroClicked(destination)
       window.location.href = destination
     }
   }
@@ -132,6 +134,7 @@ BaseContentfulTout.propTypes = {
   displayTitle: PropTypes.string,
   searchTerm: PropTypes.string,
   productsFound: PropTypes.bool,
+  segmentHeroClicked: PropTypes.func,
   emptySearchSuggestions: PropTypes.array,
   fields: PropTypes.shape({
     backgroundColor: PropTypes.string,


### PR DESCRIPTION
#### What does this PR do?

Adds `segmentHeroClicked` to `BaseContentfulTout`.

Adds `destination` property to `segmentHeroClicked`.

#### Relevant Tickets

- [ch6470]
  - https://app.clubhouse.io/rockets/story/6470/hero-clicked-event-fires-when-customer-clicks-hero-image