### PR TITLE
[ch6493] Reduce padding below clickable hero on mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.425",
+  "version": "0.1.426",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.425",
+  "version": "0.1.426",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/contentful/touts/contentfulTout.js
+++ b/src/modules/contentful/touts/contentfulTout.js
@@ -74,7 +74,7 @@ const ContentfulTout = styled(BaseContentfulTout)`
     margin-bottom: 6rem;
   `}
   ${props => props.fields.hero && props.theme.breakpointsVerbose.belowTablet`
-    padding-bottom: 6rem;
+    margin-bottom: 5rem;
   `}
 
   .roa-tout-overlay {


### PR DESCRIPTION
#### What does this PR do?

Reduces padding below clickable hero on mobile.

Swaps `padding-bottom` with `margin-bottom` in that scope.

#### Relevant Tickets

- [ch6493]
  - https://app.clubhouse.io/rockets/story/6493/mobile-customer-sees-more-content-in-homepage-viewport-when-only-1-button-is-used-in-hero