### PR TITLE
Display dot indicator within the ContentfulSlider

### DIFF
--- a/src/modules/contentful/slider/contentfulSlider.js
+++ b/src/modules/contentful/slider/contentfulSlider.js
@@ -8,6 +8,50 @@ import { RightArrow, LeftArrow } from './sliderArrows';
 
 const Container = styled.div`
   position: relative;
+  padding-bottom: 20px;
+
+  .slick-dots {
+    position: absolute;
+    bottom: -25px;
+    display: block;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    text-align: center;
+  }
+
+  .slick-dots li {
+    position: relative;
+    display: inline-block;
+    margin: 0 12px;
+    padding: 0;
+    cursor: pointer;
+  }
+
+  .slick-dots li button {
+    line-height: 0;
+    display: block;
+    width: 10px;
+    height: 10px;
+    cursor: pointer;
+    padding: 0;
+    outline: none;
+    border-radius: 5px;
+    color: transparent;
+    border: 1px solid ${props => props.theme.colors.navy};
+    background-color: #FFF;
+    transition: background-color 200ms ease-out;
+  }
+
+  .slick-dots li.slick-active button {
+    background-color: ${props => props.theme.colors.navy};
+  }
+
+  .slick-dots li button:hover,
+  .slick-dots li button:focus {
+    outline: none;
+  }
 `
 
 class ContentfulSlider extends React.Component {
@@ -19,7 +63,8 @@ class ContentfulSlider extends React.Component {
     this.next = this.next.bind(this)
 
     this.config = {
-      arrows: false
+      arrows: false,
+      dots: true
     }
   }
 


### PR DESCRIPTION
#### What does this PR do?
With this change we'll display the dot indicator within the ContentfulSlider component so users can know which slide they're currently watching and how many slides there are.

#### Screenshots
![Demo](http://recordit.co/ueDJ0NlVd5.gif)

#### Relevant Tickets
https://app.clubhouse.io/rockets/story/6560/customer-can-see-how-many-stories-are-in-homepage-hero-carousel
