### PR TITLE
Display buttons inside of contentful slides

### DIFF
--- a/src/modules/contentful/slider/contentfulSlide.js
+++ b/src/modules/contentful/slider/contentfulSlide.js
@@ -1,11 +1,36 @@
 import React from 'react';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
-import { ContentfulResponsiveImages } from 'SRC';
+import { ContentfulResponsiveImages, ContentfulButton } from 'SRC';
 
-const ContentfulSlide = ({ fields }) => (
-  <ContentfulResponsiveImages {...fields.image} />
-)
+const Container = styled.div`
+  position: relative;
+`
+
+const ButtonContainer = styled.div`
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  text-align: center;
+  padding-bottom: 10px;
+  ${props => props.theme.breakpointsVerbose.aboveTablet`
+    padding-bottom; 0;
+  `}
+`
+
+const ContentfulSlide = ({ fields }) => {
+  const buttons = fields.buttons || [];
+  return (
+    <Container>
+      <ContentfulResponsiveImages {...fields.image} />
+      <ButtonContainer>
+        {buttons.map(button => <ContentfulButton {...button} />)}
+      </ButtonContainer>
+    </Container>
+  )
+}
+
 
 ContentfulSlide.propTypes = {
   fields: PropTypes.object.isRequired

--- a/src/modules/contentful/slider/contentfulSlider.js
+++ b/src/modules/contentful/slider/contentfulSlider.js
@@ -8,7 +8,7 @@ import { RightArrow, LeftArrow } from './sliderArrows';
 
 const Container = styled.div`
   position: relative;
-  padding-bottom: 20px;
+  padding-bottom: 35px;
 
   .slick-dots {
     position: absolute;

--- a/src/modules/contentful/slider/defaultProps.js
+++ b/src/modules/contentful/slider/defaultProps.js
@@ -43,7 +43,18 @@ export default {
                 }
               }
             }
-          }
+          },
+          buttons: [
+            {
+              fields: {
+                buttonText: "SHOP CRAZYSOFT",
+                route: "/shop/girls-new-arrivals",
+                color: "#00003c",
+                backgroundColor: "#f5ff42",
+                width: "Fit Text"
+              }
+            }
+          ]
         }
       },
       {


### PR DESCRIPTION
#### What does this PR do?
With this change we'll display any buttons associated with contentful slides so we can add CTAs to our slides.

#### Screenshots
<img width="1280" alt="Screen Shot 2020-02-11 at 4 57 57 PM" src="https://user-images.githubusercontent.com/1505446/74287489-b1acad80-4cef-11ea-8815-77fae874617b.png">

#### Relevant Tickets
https://app.clubhouse.io/rockets/story/6564/customer-can-navigate-to-content-from-homepage-hero
