### PR TITLE
Allow users to click anywhere on a slide to navigate

### DIFF
--- a/src/modules/contentful/slider/contentfulSlide.js
+++ b/src/modules/contentful/slider/contentfulSlide.js
@@ -20,10 +20,16 @@ const ButtonContainer = styled.div`
 `
 
 const ContentfulSlide = ({ fields }) => {
-  const buttons = fields.buttons || [];
+  const buttons = fields.buttons || []
+
+  let image = <ContentfulResponsiveImages {...fields.image} />
+  if (fields.url) {
+    image = <a href={fields.url}>{image}</a>
+  }
+
   return (
     <Container>
-      <ContentfulResponsiveImages {...fields.image} />
+      {image}
       <ButtonContainer>
         {buttons.map(button => <ContentfulButton {...button} />)}
       </ButtonContainer>

--- a/src/modules/contentful/slider/contentfulSlider.js
+++ b/src/modules/contentful/slider/contentfulSlider.js
@@ -8,7 +8,11 @@ import { RightArrow, LeftArrow } from './sliderArrows';
 
 const Container = styled.div`
   position: relative;
-  padding-bottom: 35px;
+  margin-bottom: 4rem;
+
+  ${props => props.theme.breakpointsVerbose.aboveTablet`
+    margin-bottom: 6rem;
+  `}
 
   .slick-dots {
     position: absolute;

--- a/src/modules/contentful/slider/defaultProps.js
+++ b/src/modules/contentful/slider/defaultProps.js
@@ -44,6 +44,7 @@ export default {
               }
             }
           },
+          url: '/shop/girls-new-arrivals',
           buttons: [
             {
               fields: {


### PR DESCRIPTION
#### What does this PR do?
With this change we'll allow customers to click anywhere on a slide to navigate, the image will only be clickable when the URL field is set on contentful.

#### Relevant Tickets
https://app.clubhouse.io/rockets/story/6564/customer-can-navigate-to-content-from-homepage-hero
