### PR TITLE
[ch6575] Add segmentHeroClicked to ContentfulSlider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.429",
+  "version": "0.1.430",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.429",
+  "version": "0.1.430",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/contentful/slider/contentfulSlide.js
+++ b/src/modules/contentful/slider/contentfulSlide.js
@@ -19,12 +19,20 @@ const ButtonContainer = styled.div`
   `}
 `
 
-const ContentfulSlide = ({ fields }) => {
+const ContentfulSlide = ({ fields, segmentHeroClicked, position }) => {
   const buttons = fields.buttons || []
 
   let image = <ContentfulResponsiveImages {...fields.image} />
   if (fields.url) {
-    image = <a href={fields.url}>{image}</a>
+    const triggerSegmentHeroClicked = () => {
+      // Asset (image URL), destination, name, and position
+      if (fields.image && fields.image.fields && fields.image.fields.defaultImage) {
+        const assetUrl = `https:${fields.image.fields.defaultImage.fields.file.url}`
+        segmentHeroClicked(assetUrl, fields.url, fields.image.fields.title, position)
+      }
+    }
+
+    image = <a href={fields.url} onClick={triggerSegmentHeroClicked}>{image}</a>
   }
 
   return (
@@ -37,9 +45,10 @@ const ContentfulSlide = ({ fields }) => {
   )
 }
 
-
 ContentfulSlide.propTypes = {
-  fields: PropTypes.object.isRequired
+  fields: PropTypes.object.isRequired,
+  segmentHeroClicked: PropTypes.func.isRequired,
+  position: PropTypes.number.isRequired
 }
 
-export default ContentfulSlide;
+export default ContentfulSlide

--- a/src/modules/contentful/slider/contentfulSlider.js
+++ b/src/modules/contentful/slider/contentfulSlider.js
@@ -85,13 +85,16 @@ class ContentfulSlider extends React.Component {
   }
 
   render() {
-    const { fields } = this.props
+    const { fields, segmentHeroClicked } = this.props
+
     return (
       <Container>
         <Slider ref={this.setSlider} {...this.config}>
-          {fields.slides.map(slide => <ContentfulSlide {...slide} />)}
+          {fields.slides.map((slide, index) => {
+            return <ContentfulSlide {...slide} position={index + 1} segmentHeroClicked={segmentHeroClicked} />
+          })}
         </Slider>
-        <LeftArrow onClick={this.previous}/>
+        <LeftArrow onClick={this.previous} />
         <RightArrow onClick={this.next} />
       </Container>
     )


### PR DESCRIPTION
#### What does this PR do?

Adds `segmentHeroClicked` to `ContentfulSlider`.

Includes `asset` (image URL), `destination`, `name`, and `position`.

#### Relevant Tickets

- [ch6575]
  - https://app.clubhouse.io/rockets/story/6575/add-asset-name-position-and-number-of-slides-attributes-to-hero-clicked-event