### PR TITLE
[ch6575] Prevent segmentHeroClicked on drag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.432",
+  "version": "0.1.433",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.432",
+  "version": "0.1.433",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/contentful/slider/contentfulSlide.js
+++ b/src/modules/contentful/slider/contentfulSlide.js
@@ -19,14 +19,15 @@ const ButtonContainer = styled.div`
   `}
 `
 
-const ContentfulSlide = ({ fields, segmentHeroClicked, position, totalSlides }) => {
+const ContentfulSlide = ({ fields, isSliding, segmentHeroClicked, position, totalSlides }) => {
   const buttons = fields.buttons || []
 
   let image = <ContentfulResponsiveImages {...fields.image} />
   if (fields.url) {
     const triggerSegmentHeroClicked = () => {
       // Asset (image URL), destination, name, and position
-      if (fields.image && fields.image.fields && fields.image.fields.defaultImage) {
+      // Only call segmentHeroClicked on actual click, not dragging click
+      if (fields.image && fields.image.fields && fields.image.fields.defaultImage && !isSliding()) {
         const assetUrl = `https:${fields.image.fields.defaultImage.fields.file.url}`
         segmentHeroClicked(assetUrl, fields.url, fields.image.fields.title, position, totalSlides)
       }
@@ -47,6 +48,7 @@ const ContentfulSlide = ({ fields, segmentHeroClicked, position, totalSlides }) 
 
 ContentfulSlide.propTypes = {
   fields: PropTypes.object.isRequired,
+  isSliding: PropTypes.func.isRequired,
   segmentHeroClicked: PropTypes.func.isRequired,
   position: PropTypes.number.isRequired,
   totalSlides: PropTypes.number.isRequired

--- a/src/modules/contentful/slider/contentfulSlider.js
+++ b/src/modules/contentful/slider/contentfulSlider.js
@@ -62,15 +62,22 @@ class ContentfulSlider extends React.Component {
   constructor(props) {
     super(props)
 
+    this.isSliding = this.isSliding.bind(this)
     this.setSlider = this.setSlider.bind(this)
     this.previous = this.previous.bind(this)
     this.next = this.next.bind(this)
     this.triggerSegmentHeroViewed = this.triggerSegmentHeroViewed.bind(this)
 
+    this.sliding = false
+
     this.config = {
       arrows: false,
       dots: true,
-      afterChange: (currentSlidePosition) => this.triggerSegmentHeroViewed(currentSlidePosition)
+      beforeChange: (currentSlidePosition) => { this.sliding = true },
+      afterChange: (currentSlidePosition) => {
+        this.sliding = false
+        this.triggerSegmentHeroViewed(currentSlidePosition)
+      }
     }
   }
 
@@ -81,6 +88,11 @@ class ContentfulSlider extends React.Component {
 
   setSlider(slider) {
     this.slider = slider
+  }
+
+  // Send function into ContentfulSlide, since it is only rendered once
+  isSliding() {
+    return this.sliding
   }
 
   previous() {
@@ -124,6 +136,7 @@ class ContentfulSlider extends React.Component {
                 position={index + 1}
                 totalSlides={fields.slides.length}
                 segmentHeroClicked={segmentHeroClicked}
+                isSliding={this.isSliding}
               />
             )
           })}


### PR DESCRIPTION
#### What does this PR do?

Prevents triggering of `segmentHeroClicked` on drag.

Activates `segmentHeroClicked` only on regular click.

#### Relevant Tickets

- [ch6575]
  - https://app.clubhouse.io/rockets/story/6575/add-asset-name-position-and-number-of-slides-attributes-to-hero-clicked-event