### PR TITLE
[ch6678] Prevent some mobile Safari users from clicking ContentfulSlider twice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.433",
+  "version": "0.1.434",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.433",
+  "version": "0.1.434",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/contentful/slider/contentfulSlider.js
+++ b/src/modules/contentful/slider/contentfulSlider.js
@@ -77,6 +77,11 @@ class ContentfulSlider extends React.Component {
       afterChange: (currentSlidePosition) => {
         this.sliding = false
         this.triggerSegmentHeroViewed(currentSlidePosition)
+
+        // Prevent some mobile Safari users from clicking twice (after slide) to navigate
+        if (this.slider && this.slider.innerSlider) {
+          this.slider.innerSlider.clickable = true
+        }
       }
     }
   }


### PR DESCRIPTION
#### What does this PR do?

Prevents some mobile Safari users from clicking `ContentfulSlider` twice (after slide) to navigate to destination.

Sets `this.slider.innerSlider.clickable` to `true` at end of `afterChange`.

#### Relevant Tickets

- [ch6678]
  - https://app.clubhouse.io/rockets/story/6678/some-customers-have-to-click-hero-slide-twice-to-be-directed-to-destination