### PR TITLE
[ch6441] Add segmentProductRemoved to PersistentCartProduct

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.434",
+  "version": "0.1.435",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.434",
+  "version": "0.1.435",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/persistent-cart/cartSidebar/cartSidebar.js
+++ b/src/modules/persistent-cart/cartSidebar/cartSidebar.js
@@ -274,6 +274,7 @@ class BaseCartSidebar extends React.Component {
       promotionLoading,
       promoHasBeenApplied,
       promoErrorMessage,
+      segmentProductRemoved,
       applyPromotion,
       removePromotion,
       appliedPromotion,
@@ -331,6 +332,7 @@ class BaseCartSidebar extends React.Component {
                 removeItem={removeItem}
                 renderProductLink={renderProductLink}
                 segmentCartViewed={segmentCartViewed}
+                segmentProductRemoved={segmentProductRemoved}
               />
               :
               <EmptyCart />
@@ -410,6 +412,7 @@ BaseCartSidebar.propTypes = {
   promotionLoading: PropTypes.bool,
   promoHasBeenApplied: PropTypes.bool,
   promoErrorMessage: PropTypes.string,
+  segmentProductRemoved: PropTypes.func,
   applyPromotion: PropTypes.func,
   removePromotion: PropTypes.func,
   appliedPromotion: PropTypes.object,

--- a/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.js
+++ b/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.js
@@ -119,8 +119,10 @@ class BaseProduct extends React.Component {
   }
 
   _onRemoveItem = () => {
-    const { item } = this.props
+    const { item, segmentProductRemoved } = this.props
+
     this.props.onRemoveItem(item.id)
+    segmentProductRemoved(item)
   }
 
   _renderQuantityPicker = () => {
@@ -234,7 +236,8 @@ BaseProduct.propTypes = {
   onRemoveItem: PropTypes.func,
   hideCartSidebar: PropTypes.func,
   className: PropTypes.string,
-  renderLink: PropTypes.func
+  renderLink: PropTypes.func,
+  segmentProductRemoved: PropTypes.func
 }
 
 BaseProduct.defaultProps = {

--- a/src/modules/persistent-cart/persistentCartProductList/persistentCartProductList.js
+++ b/src/modules/persistent-cart/persistentCartProductList/persistentCartProductList.js
@@ -36,7 +36,8 @@ class BasePersistentCartProductList extends Component {
       updateBag,
       removeItem,
       hideCartSidebar,
-      renderProductLink
+      renderProductLink,
+      segmentProductRemoved
     } = this.props
 
     return (
@@ -50,6 +51,7 @@ class BasePersistentCartProductList extends Component {
                 onUpdateQuantity={updateBag}
                 onRemoveItem={removeItem}
                 renderLink={renderProductLink}
+                segmentProductRemoved={segmentProductRemoved}
                 hideCartSidebar={hideCartSidebar} />
             )}
           </BagListWrapper>
@@ -70,6 +72,7 @@ BasePersistentCartProductList.propTypes = {
   removeItem: PropTypes.func,
   hideCartSidebar: PropTypes.func,
   segmentCartViewed: PropTypes.func,
+  segmentProductRemoved: PropTypes.func,
   renderProductLink: PropTypes.func
 }
 


### PR DESCRIPTION
#### What does this PR do?

Adds `segmentProductRemoved` to `PersistentCartProduct`.

Sends `item` into `segmentProductRemoved`, which has context of `products`, `colorways`, and `variants`.

#### Relevant Tickets

- [ch6441]
  - https://app.clubhouse.io/rockets/story/6441/fix-product-removed-event