### PR TITLE
Customer Sees Returns Link on Homepage Underneath [ch6709]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.435",
+  "version": "0.1.436",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.435",
+  "version": "0.1.436",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -10,7 +10,8 @@ const LINKS = {
   'twitter': 'https://twitter.com/rocketsofawesom',
   'instagram': 'https://www.instagram.com/rocketsofawesome',
   'snapchat': 'https://www.snapchat.com/add/rocketsofawesom',
-  'contact-us': 'https://support.rocketsofawesome.com/hc/en-us/articles/115015922347'
+  'contact-us': 'https://support.rocketsofawesome.com/hc/en-us/articles/115015922347',
+  'returns': 'https://support.rocketsofawesome.com/hc/en-us/articles/360031271434-How-do-returns-work-for-my-online-order'
 }
 
 const BaseFooter = ({
@@ -48,6 +49,9 @@ const BaseFooter = ({
             <ul>
               <li>
                 <WhiteLink light href={LINKS['faq']} target='_blank'>Help</WhiteLink>
+              </li>
+              <li>
+                <WhiteLink light href={LINKS['returns']} target='_blank'>Returns</WhiteLink>
               </li>
             </ul>
           </FlexCol>


### PR DESCRIPTION
#### What does this PR do?

Customer Sees Returns Link on Homepage Underneath Help Link
As a customer, I want to easily find returns information on the homepage so I can return unwanted items.

Acceptance Criteria

Returns link appears directly beneath Help link
Returns link links to: https://support.rocketsofawesome.com/hc/en-us/articles/360031271434-How-do-returns-work-for-my-online-order-

#### Screenshots

![image](https://user-images.githubusercontent.com/1105891/75693682-4e21fa00-5c75-11ea-9276-05ee28a8e989.png)

#### Notes


#### PR Dependencies


#### Relevant Tickets

https://app.clubhouse.io/rockets/story/6709/customer-sees-returns-link-on-homepage-underneath-help-link