### PR TITLE
[ch6741] Send final sale prop to cartSideBar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.436",
+  "version": "0.1.437",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.436",
+  "version": "0.1.437",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/persistent-cart/cartSidebar/cartSidebar.js
+++ b/src/modules/persistent-cart/cartSidebar/cartSidebar.js
@@ -282,7 +282,8 @@ class BaseCartSidebar extends React.Component {
       currentUserEmail,
       onClickCheckout,
       onClickPaymentRequestButton,
-      giftFeatureOn
+      giftFeatureOn,
+      finalSaleOn
     } = this.props
     if (!shouldShowCartSidebar) return null
 
@@ -333,6 +334,7 @@ class BaseCartSidebar extends React.Component {
                 renderProductLink={renderProductLink}
                 segmentCartViewed={segmentCartViewed}
                 segmentProductRemoved={segmentProductRemoved}
+                finalSaleOn={finalSaleOn}
               />
               :
               <EmptyCart />
@@ -419,14 +421,16 @@ BaseCartSidebar.propTypes = {
   renderProductLink: PropTypes.func,
   currentUserEmail: PropTypes.string,
   giftFeatureOn: PropTypes.bool,
-  scrollKeepShopping: PropTypes.oneOfType([PropTypes.bool, PropTypes.func])
+  scrollKeepShopping: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+  finalSaleOn: PropTypes.bool
 }
 
 BaseCartSidebar.defaultProps = {
   renderLink: renderLink,
   renderProductLink: renderLink,
   giftFeatureOn: false,
-  scrollKeepShopping: false
+  scrollKeepShopping: false,
+  finalSaleOn: false
 }
 
 const CartSidebar = styled(BaseCartSidebar)`

--- a/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.js
+++ b/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.js
@@ -162,7 +162,7 @@ class BaseProduct extends React.Component {
   }
 
   render () {
-    const { item, hideCartSidebar, className, renderLink } = this.props
+    const { item, hideCartSidebar, className, renderLink, finalSaleOn } = this.props
     const isOutOfStock = this._isOutOfStock()
 
     return (
@@ -201,7 +201,7 @@ class BaseProduct extends React.Component {
               {this._getNotEnoughQuantityError()}
             </Attribute>
           }
-          {item.on_sale && <FinalSale>FINAL SALE</FinalSale>}
+          {item.on_sale && finalSaleOn && <FinalSale>FINAL SALE</FinalSale>}
         </div>
         {this._showRemoveItem() && <Remove onClick={this._onRemoveItem} />}
       </div>
@@ -237,7 +237,8 @@ BaseProduct.propTypes = {
   hideCartSidebar: PropTypes.func,
   className: PropTypes.string,
   renderLink: PropTypes.func,
-  segmentProductRemoved: PropTypes.func
+  segmentProductRemoved: PropTypes.func,
+  finalSaleOn: PropTypes.bool
 }
 
 BaseProduct.defaultProps = {

--- a/src/modules/persistent-cart/persistentCartProductList/persistentCartProductList.js
+++ b/src/modules/persistent-cart/persistentCartProductList/persistentCartProductList.js
@@ -37,7 +37,8 @@ class BasePersistentCartProductList extends Component {
       removeItem,
       hideCartSidebar,
       renderProductLink,
-      segmentProductRemoved
+      segmentProductRemoved,
+      finalSaleOn
     } = this.props
 
     return (
@@ -52,7 +53,9 @@ class BasePersistentCartProductList extends Component {
                 onRemoveItem={removeItem}
                 renderLink={renderProductLink}
                 segmentProductRemoved={segmentProductRemoved}
-                hideCartSidebar={hideCartSidebar} />
+                hideCartSidebar={hideCartSidebar}
+                finalSaleOn={finalSaleOn}
+              />
             )}
           </BagListWrapper>
         </BagListBody>


### PR DESCRIPTION
#### What does this PR do?

Sends `finalSaleOn` prop to cartSideBar, which determines whether to show "FINAL SALE" copy below sale items in bag.

#### PR Dependencies

PR in Thor and Quark UI

#### Relevant Tickets

[ch6741]
https://app.clubhouse.io/rockets/story/6741/make-an-env-variable-for-final-sale-language

[ch6742]
https://app.clubhouse.io/rockets/story/6742/customer-only-sees-final-sale-label-logic-on-sale-items-that-are-final-sale