### PR TITLE
Ch6757 plp highlighter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.440",
+  "version": "0.1.441",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.440",
+  "version": "0.1.441",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/productTile/productPrice/productPrice.js
+++ b/src/modules/productTile/productPrice/productPrice.js
@@ -33,7 +33,9 @@ const BaseProductPrice = ({ colorway, className }) => {
   return (
     <div className={className}>
       {pricingLine}
-      <Text color={theme.colors.rocketBlue}>{formatPrice(promoPrice)} with 4+ items</Text>
+      <Text style={{backgroundColor: theme.colors.yellow}}>
+        {formatPrice(promoPrice)} with 4+ items
+      </Text>
     </div>
   )
 }


### PR DESCRIPTION
#### What does this PR do?

Adds highlighter background color to evergreen promo on product tiles.

![Screen Shot 2020-03-11 at 4 09 00 PM](https://user-images.githubusercontent.com/43832282/76459497-b0d06f80-63b2-11ea-92fa-35b525f0f31f.png)

#### Relevant Tickets

[ch6757]
https://app.clubhouse.io/rockets/story/6757/customers-see-evergreen-promo-price-highlighted-in-yellow
