### PR TITLE
Ensure the current colorway is used for quick view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.447",
+  "version": "0.1.448",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.447",
+  "version": "0.1.448",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/productTile/productTile.base.js
+++ b/src/modules/productTile/productTile.base.js
@@ -52,7 +52,9 @@ export default class ProductTile extends React.Component {
 
   handleQuickViewClick = () => {
     const { product, onQuickView } = this.props
-    onQuickView(product)
+    const { selectedColorway } = this.state
+    const colorway = this.getColorway(selectedColorway)
+    onQuickView(product, colorway)
   }
 
   changeColorway = (code) => ({ target }) => {

--- a/src/modules/productTile/productTile.md
+++ b/src/modules/productTile/productTile.md
@@ -3,7 +3,7 @@
   <div style={{ width: '33.33%'}}>
     <ProductTile
       {...require('./defaultProps').productWithVariants}
-      onQuickView={(product) => console.log('Quick view', product)}
+      onQuickView={(product, colorway) => console.log('Quick view', product, colorway)}
     />
   </div>
 ```


### PR DESCRIPTION
#### What does this PR do?
With this change we'll tweak the ProductTile component so the onQuickView callback receives information about the colorway that is currently in display on the tile.

This will allow us to display the right colorway when the quick view modal is opened.