### PR TITLE
[ch6819] Add percent discount to product tiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.449",
+  "version": "0.1.450",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.449",
+  "version": "0.1.450",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/outfits/outfitSizePicker/outfitSizePicker.js
+++ b/src/modules/outfits/outfitSizePicker/outfitSizePicker.js
@@ -11,6 +11,18 @@ const OutfitProductImage = ({product}) => (
     {...product.image} />
 )
 
+const Discount = styled.span`
+  margin-left: 4px;
+  color: ${props => props.theme.colors.rocketBlue}
+`
+
+const Price = styled.span`
+  font-weight: normal;
+  color: #6d7278;
+  margin-left: 8px;
+  text-decoration: line-through;
+`
+
 const OutfitSizePicker = styled(({
   className,
   currentSizes,
@@ -26,6 +38,7 @@ const OutfitSizePicker = styled(({
         const currentSize = currentSizes && (product.id in currentSizes) ? currentSizes[product.id] : undefined
         const originalPrice = product.original_price
         const onSale = product.on_sale
+        const discountPercent = product.discount_percent
         return (
           <div className='roa-product' key={product.id}>
             <div className='roa-image-wrapper'>
@@ -36,7 +49,8 @@ const OutfitSizePicker = styled(({
                 {onSale ?
                   <span>
                     {accounting.formatMoney(product.price)}
-                    <span className='original-price'>{accounting.formatMoney(originalPrice)}</span>
+                    <Price>{accounting.formatMoney(originalPrice)}</Price>
+                    <Discount>{parseInt(discountPercent)}% Off</Discount>
                   </span>
                   :
                   accounting.formatMoney(product.price)

--- a/src/modules/productTile/defaultProps.js
+++ b/src/modules/productTile/defaultProps.js
@@ -95,8 +95,9 @@ const productOnSale = {
             "id": 18009,
             "sku": "A222-C01-A",
             "size": "OS",
-            "price": 10.0,
-            "original_price": 24.5,
+            "price": 19.88,
+            "original_price": 26.50,
+            "discount_percent": 25,
             "cost_price": null,
             "in_stock": true
           }

--- a/src/modules/productTile/productPrice/productPrice.js
+++ b/src/modules/productTile/productPrice/productPrice.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { P, formatPrice, theme } from 'SRC'
+import { P, formatPrice } from 'SRC'
 
 const Text = styled(P)`
   font-weight: 500;
@@ -16,6 +16,7 @@ const formatSalePrice = (price) => {
 const BaseProductPrice = ({ colorway, className }) => {
   const originalPrice = colorway.skus[0].original_price
   const price = colorway.skus[0].price
+  const discountPercent = colorway.skus[0].discount_percent
   const onSale = originalPrice && originalPrice !== 0 && price < originalPrice
   const promoPrice = parseFloat(price) * 0.8
 
@@ -26,6 +27,7 @@ const BaseProductPrice = ({ colorway, className }) => {
       <Text>
         {formatSalePrice(price)}
         <span className="original-price">{formatPrice(originalPrice)}</span>
+        <span className="discount-percent">{discountPercent}% off</span>
       </Text>
     )
   }
@@ -33,8 +35,8 @@ const BaseProductPrice = ({ colorway, className }) => {
   return (
     <div className={className}>
       {pricingLine}
-      <Text style={{backgroundColor: theme.colors.yellow}}>
-        {formatPrice(promoPrice)} with 4+ items
+      <Text>
+        <span className="highlighter">{formatPrice(promoPrice)} with 4+ items</span>
       </Text>
     </div>
   )
@@ -46,6 +48,13 @@ const ProductPrice = styled(BaseProductPrice)`
     color: #6d7278;
     margin-left: 8px;
     text-decoration: line-through;
+  }
+  .discount-percent {
+    margin-left: 4px;
+    color: ${props => props.theme.colors.rocketBlue}
+  }
+  .highlighter {
+    background-color: ${props => props.theme.colors.yellow}
   }
 `
 

--- a/src/modules/productTile/productPrice/productPrice.js
+++ b/src/modules/productTile/productPrice/productPrice.js
@@ -8,12 +8,28 @@ const Text = styled(P)`
   font-size: 14px;
 `;
 
+const Discount = styled.span`
+  margin-left: 4px;
+  color: ${props => props.theme.colors.rocketBlue}
+`
+
+const Price = styled.span`
+  font-weight: normal;
+  color: #6d7278;
+  margin-left: 8px;
+  text-decoration: line-through;
+`
+
+const HighlightedText = styled.span`
+  background-color: ${props => props.theme.colors.yellow}
+`
+
 const formatSalePrice = (price) => {
   const decimalPlaces = parseInt(price, 10) === parseFloat(price) ? 0 : 2
   return formatPrice(price, "$", decimalPlaces)
 }
 
-const BaseProductPrice = ({ colorway, className }) => {
+const ProductPrice = ({ colorway, className }) => {
   const originalPrice = colorway.skus[0].original_price
   const price = colorway.skus[0].price
   const discountPercent = colorway.skus[0].discount_percent
@@ -26,8 +42,8 @@ const BaseProductPrice = ({ colorway, className }) => {
     pricingLine = (
       <Text>
         {formatSalePrice(price)}
-        <span className="original-price">{formatPrice(originalPrice)}</span>
-        <span className="discount-percent">{discountPercent}% off</span>
+        <Price>{formatPrice(originalPrice)}</Price>
+        <Discount>{parseInt(discountPercent)}% off</Discount>
       </Text>
     )
   }
@@ -36,29 +52,13 @@ const BaseProductPrice = ({ colorway, className }) => {
     <div className={className}>
       {pricingLine}
       <Text>
-        <span className="highlighter">{formatPrice(promoPrice)} with 4+ items</span>
+        <HighlightedText>{formatPrice(promoPrice)} with 4+ items</HighlightedText>
       </Text>
     </div>
   )
 }
 
-const ProductPrice = styled(BaseProductPrice)`
-  .original-price {
-    font-weight: normal;
-    color: #6d7278;
-    margin-left: 8px;
-    text-decoration: line-through;
-  }
-  .discount-percent {
-    margin-left: 4px;
-    color: ${props => props.theme.colors.rocketBlue}
-  }
-  .highlighter {
-    background-color: ${props => props.theme.colors.yellow}
-  }
-`
-
-BaseProductPrice.propTypes = {
+ProductPrice.propTypes = {
   colorway: PropTypes.object,
   className: PropTypes.string
 }


### PR DESCRIPTION
#### What does this PR do?

Adds percent discount next to the crossed out original price on product tiles.

![Screen Shot 2020-03-30 at 11 59 29 AM](https://user-images.githubusercontent.com/43832282/77934333-f085cb00-727d-11ea-8cfd-c05b6dffe1c0.png)

#### PR Dependencies

PRs on Quark (https://github.com/rocketsofawesome/quark/pull/1897) and Thor

#### Relevant Tickets

[ch6819]
https://app.clubhouse.io/rockets/story/6819/customers-see-percent-discount-off-on-sale-item-cards