### PR TITLE
Allow mobile customers to view quick view with a single tap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.448",
+  "version": "0.1.449",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.448",
+  "version": "0.1.449",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/inputs/Checkbox/Checkbox.js
+++ b/src/components/inputs/Checkbox/Checkbox.js
@@ -88,9 +88,7 @@ class CheckboxBase extends React.Component {
 
 CheckboxBase.propTypes = {
   className: PropTypes.string,
-  input: PropTypes.shape({
-    value: PropTypes.bool
-  }).isRequired,
+  input: PropTypes.object.isRequired,
   label: PropTypes.string
 }
 

--- a/src/core/image/inlineImage.js
+++ b/src/core/image/inlineImage.js
@@ -40,7 +40,10 @@ InlineImage.defaultProps = {
 
 InlineImage.propTypes = {
   alt: PropTypes.string.isRequired,
-  lazyLoad: PropTypes.string,
+  lazyLoad: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool
+  ]),
   src: PropTypes.string.isRequired,
   sizes: PropTypes.object,
   srcSet: PropTypes.oneOfType([


### PR DESCRIPTION
#### What does this PR do?
With this change we'll allow customers browsing our site on their mobile devices to access quick view by tapping on the slider of each product tile. Desktop users will only be able to access quick view by clicking on the quick view button which will only be visible in desktop.

#### Relevant Tickets
https://app.clubhouse.io/rockets/story/6847/mobile-customer-sees-quickview-after-tapping-the-product-tile-once
