### PR TITLE
Allow open in new tab for product tiles on laptop screen width

### DIFF
--- a/src/components/images/slider/slider.base.js
+++ b/src/components/images/slider/slider.base.js
@@ -56,8 +56,8 @@ export class BaseROASlider extends Component {
   }
 
   render() {
-    const { className, images, onClick, lazyLoad } = this.props
-
+    const { className, images, onClick, lazyLoad, renderLink, target } = this.props
+    const Link = renderLink
     return (
       <div
         className={className}
@@ -68,18 +68,36 @@ export class BaseROASlider extends Component {
           ref={this.setSlider}
           {...this.config}
         >
-          {images.map((image, index) => (
-            <InlineImage
-              key={index}
-              alt={image.alt}
-              src={cloudinary.url(image.src, {
-                transformation: 'plp_product_shot',
-                format: 'jpg'
-              })}
-              onClick={onClick}
-              lazyLoad={lazyLoad}
-            />
-          ))}
+          {images.map((image, index) => {
+            if (renderLink && target) {
+              return (
+                <Link target={target} key={index}>
+                  <InlineImage
+                    alt={image.alt}
+                    src={cloudinary.url(image.src, {
+                      transformation: 'plp_product_shot',
+                      format: 'jpg'
+                    })}
+                    lazyLoad={lazyLoad}
+                  />
+                </Link>
+              )
+            } else {
+              return (
+                <InlineImage
+                  key={index}
+                  alt={image.alt}
+                  src={cloudinary.url(image.src, {
+                    transformation: 'plp_product_shot',
+                    format: 'jpg'
+                  })}
+                  onClick={onClick}
+                  lazyLoad={lazyLoad}
+                />
+              )
+            }
+          })
+          }
         </Slider>
         {(images.length > 1) &&
           <div>
@@ -100,7 +118,9 @@ BaseROASlider.propTypes = {
   sliderLazyLoad: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.string
-  ])
+  ]),
+  target: PropTypes.string,
+  renderLink: PropTypes.func
 }
 
 BaseROASlider.defaultProps = {

--- a/src/modules/productTile/productTile.base.js
+++ b/src/modules/productTile/productTile.base.js
@@ -13,6 +13,18 @@ import { withSortedShots } from 'SRC/utils'
 
 const SortedROASlider = withSortedShots(ROASlider)
 
+const AboveLaptopSlider = styled.div`
+  ${props => props.theme.breakpointsVerbose.belowLaptop`
+    display: none;
+  `}
+`
+
+const BelowLaptopSlider = styled.div`
+  ${props => props.theme.breakpointsVerbose.aboveLaptop`
+    display: none;
+  `}
+`
+
 const SliderContainer = styled.div`
   position: relative;
   cursor: pointer;
@@ -30,10 +42,6 @@ const QuickView = styled.div`
   ${SliderContainer}:hover & {
     opacity: 1;
   }
-
-  ${props => props.theme.breakpointsVerbose.belowLaptop`
-    display: none;
-  `}
 `
 
 const QuickViewButton = styled(WhiteButton)`
@@ -47,18 +55,6 @@ export default class ProductTile extends React.Component {
       show: false,
       selectedColorway: props.product.code,
       lazyLoad: props.lazyLoad
-    }
-  }
-
-  handleSliderClick = () => {
-    const isMobile = window.innerWidth < theme.sizes.laptop
-    const { goToPdp } = this.props
-
-    if (isMobile) {
-      this.handleQuickViewClick()
-    } else {
-      const url = this.getUrl()
-      goToPdp(url)
     }
   }
 
@@ -95,28 +91,43 @@ export default class ProductTile extends React.Component {
     } = this.props
     const { selectedColorway, lazyLoad } = this.state
     const colorway = this.getSelectedColorway()
+    const target = `products/${product.product_slug}-${colorway.slug}`
     const Link = renderLink
 
     return (
       <div className={className}>
-        <SliderContainer>
-          <SortedROASlider
-            {...props}
-            product={product}
-            shots={colorway.shots}
-            lazyLoad={lazyLoad}
-            onClick={this.handleSliderClick}
-          />
-          <QuickView>
-            <QuickViewButton
-              width='100%'
-              height='35px'
+        <AboveLaptopSlider>
+          <SliderContainer>
+            <SortedROASlider
+              {...props}
+              product={product}
+              shots={colorway.shots}
+              lazyLoad={lazyLoad}
+              renderLink={renderLink}
+              target={target}
+            />
+            <QuickView>
+              <QuickViewButton
+                width='100%'
+                height='35px'
+                onClick={this.handleQuickViewClick}
+              >
+                Quick View
+              </QuickViewButton>
+            </QuickView>
+          </SliderContainer>
+        </AboveLaptopSlider>
+        <BelowLaptopSlider>
+          <SliderContainer>
+            <SortedROASlider
+              {...props}
+              product={product}
+              shots={colorway.shots}
+              lazyLoad={lazyLoad}
               onClick={this.handleQuickViewClick}
-            >
-              Quick View
-            </QuickViewButton>
-          </QuickView>
-        </SliderContainer>
+            />
+          </SliderContainer>
+        </BelowLaptopSlider>
         {renderLink ?
           <Link
             className='roa-product-tile-details'
@@ -144,19 +155,17 @@ ProductTile.defaultProps = {
   renderLink: ({className, children, target, ...props}) => (
     <a
       className={className}
-      href={target}
+      href={`/${target}`}
       {...props}>
       {children}
     </a>
   ),
-  onQuickView: () => null,
-  goToPdp: (url) => window.location = url
+  onQuickView: () => null
 }
 
 ProductTile.propTypes = {
   className: PropTypes.string,
   product: PropTypes.object,
   renderLink: PropTypes.func,
-  onQuickView: PropTypes.func,
-  goToPdp: PropTypes.func
+  onQuickView: PropTypes.func
 }

--- a/src/modules/productTile/productTile.base.js
+++ b/src/modules/productTile/productTile.base.js
@@ -6,8 +6,7 @@ import {
   P,
   ROASlider,
   ProductPrice,
-  WhiteButton,
-  theme
+  WhiteButton
 } from 'SRC'
 import { withSortedShots } from 'SRC/utils'
 
@@ -91,18 +90,15 @@ export default class ProductTile extends React.Component {
     } = this.props
     const { selectedColorway, lazyLoad } = this.state
     const colorway = this.getSelectedColorway()
-    const target = `products/${product.product_slug}-${colorway.slug}`
+    const target = this.getUrl()
     const Link = renderLink
-
+    const sharedSliderProps = { product, shots: colorway.shots, lazyLoad, ...props }
     return (
       <div className={className}>
         <AboveLaptopSlider>
           <SliderContainer>
             <SortedROASlider
-              {...props}
-              product={product}
-              shots={colorway.shots}
-              lazyLoad={lazyLoad}
+              {...sharedSliderProps}
               renderLink={renderLink}
               target={target}
             />
@@ -120,10 +116,7 @@ export default class ProductTile extends React.Component {
         <BelowLaptopSlider>
           <SliderContainer>
             <SortedROASlider
-              {...props}
-              product={product}
-              shots={colorway.shots}
-              lazyLoad={lazyLoad}
+              {...sharedSliderProps}
               onClick={this.handleQuickViewClick}
             />
           </SliderContainer>
@@ -155,7 +148,7 @@ ProductTile.defaultProps = {
   renderLink: ({className, children, target, ...props}) => (
     <a
       className={className}
-      href={`/${target}`}
+      href={target}
       {...props}>
       {children}
     </a>


### PR DESCRIPTION
#### What does this PR do?

Adds the Link component back in product tiles on laptop screen width.

#### Relevant Tickets

[ch6854]
https://app.clubhouse.io/rockets/story/6854/desktop-customer-can-open-product-tiles-in-new-tabs
