### PR TITLE
Replace React.Fragment with a backwards-compatible element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.456",
+  "version": "0.1.457",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.456",
+  "version": "0.1.457",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/inputs/XCheckbox/X.base.js
+++ b/src/components/inputs/XCheckbox/X.base.js
@@ -4,10 +4,10 @@ import styled from 'styled-components'
 
 const BaseX  = ({ className }) => {
   return (
-    <React.Fragment>
+    <g>
       <polyline className={className} points="155,30,30,155" fill="none" stroke="black" />
       <polyline className={className} points="30,30,155,155" fill="none" stroke="black" />
-    </React.Fragment>
+    </g>
   )
 }
 


### PR DESCRIPTION
#### What does this PR do?
With this change we'll replace the usage of the React.Fragment with the <g> element which should be compatible with older React apps (i.e quark-ui).
