### PR TITLE
[ch6952] Fix evergreen promo in product quartet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.458",
+  "version": "0.1.459",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.458",
+  "version": "0.1.459",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/contentful/productQuartet/productQuartet.js
+++ b/src/modules/contentful/productQuartet/productQuartet.js
@@ -2,14 +2,26 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { ProductTile, Quartet, Duet, Default, TabletMax } from 'SRC'
 
-const ProductQuartet = ({ className, products, ...props}) => {
+const ProductQuartet = ({
+  className,
+  products,
+  evergreenPromoItemCount,
+  evergreenPromoPercent,
+  ...props
+}) => {
   return (
     <div>
       <Default displayTarget='belowTabletMax'>
         <Duet>
           {products.map((product, index) => {
             return (
-              <ProductTile product={product} key={index} {...props} />
+              <ProductTile
+                product={product}
+                key={index}
+                evergreenPromoItemCount={evergreenPromoItemCount}
+                evergreenPromoPercent={evergreenPromoPercent}
+                {...props}
+              />
             )
           })}
         </Duet>
@@ -18,7 +30,13 @@ const ProductQuartet = ({ className, products, ...props}) => {
         <Quartet>
           {products.map((product, index) => {
             return (
-              <ProductTile product={product} key={index} {...props} />
+              <ProductTile
+                product={product}
+                key={index}
+                evergreenPromoItemCount={evergreenPromoItemCount}
+                evergreenPromoPercent={evergreenPromoPercent}
+                {...props}
+              />
             )
           })}
         </Quartet>
@@ -29,7 +47,9 @@ const ProductQuartet = ({ className, products, ...props}) => {
 
 ProductQuartet.propTypes = {
   className: PropTypes.string,
-  products: PropTypes.array
+  products: PropTypes.array,
+  evergreenPromoItemCount: PropTypes.string,
+  evergreenPromoPercent: PropTypes.string
 }
 
 export default ProductQuartet


### PR DESCRIPTION
#### What does this PR do?

Passes evergreen promo props to the ProductTiles in ProductQuartet.

#### Relevant Tickets

[ch6952]
https://app.clubhouse.io/rockets/story/6952/customer-sees-evergreen-promotion-as-6-for-20