### PR TITLE
[ch6993] Fix alignment of line items with shorter titles in bag and p…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.460",
+  "version": "0.1.461",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.460",
+  "version": "0.1.461",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/persistent-cart/cartSidebar/cartSidebar.js
+++ b/src/modules/persistent-cart/cartSidebar/cartSidebar.js
@@ -38,6 +38,9 @@ const CartSidebarContainer = styled.article`
     width: 35%;
   `}
   ${props => props.theme.breakpointsVerbose.aboveLaptop`
+    width: 30%;
+  `}
+  ${props => props.theme.breakpointsVerbose.aboveDesktop`
     width: 25%;
   `}
 `
@@ -103,6 +106,9 @@ const Footer = styled.footer`
     width: 35%;
   `}
   ${props => props.theme.breakpointsVerbose.aboveLaptop`
+    width: 30%;
+  `}
+  ${props => props.theme.breakpointsVerbose.aboveDesktop`
     width: 25%;
   `}
   }

--- a/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.js
+++ b/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.js
@@ -121,6 +121,14 @@ const Remove = styled(XIcon)`
   cursor: pointer;
 `
 
+const AttributeContainer = styled.div`
+  min-width: 150px;
+
+  ${props => props.theme.breakpointsVerbose.belowPhone`
+    min-width: 0;
+  `}
+`
+
 class BaseProduct extends React.Component {
   constructor (props) {
     super(props)
@@ -186,7 +194,7 @@ class BaseProduct extends React.Component {
             <img alt={item.description} src={this._getVariantShot()} />
           </ImageLink>
         </Thumbnail>
-        <div>
+        <AttributeContainer>
           <ItemName>
             {item.name}
           </ItemName>
@@ -212,7 +220,7 @@ class BaseProduct extends React.Component {
             </Attribute>
           }
           {item.on_sale && finalSaleOn && <FinalSale>FINAL SALE</FinalSale>}
-        </div>
+        </AttributeContainer>
         {this._showRemoveItem() && <Remove onClick={this._onRemoveItem} />}
       </div>
     )


### PR DESCRIPTION
…revent bag from becoming too narrow on some screen widths

#### What does this PR do?

This commit solves a couple styling issues with the bag.
* Adds min-width to line item title so items with shorter titles have the same alignment as other items.
* Adds another breakpoint for styling `cartSidebar` to prevent bag from getting very narrow around screen width 1000 - 1200px. This was complicating the alignment fix where either adding min-width or left-margin to the product title would cause the remove item "X" to disappear when the bag was too narrow. It also seems unnecessary and doesn't look good for the bag to become narrow for only this range.

#### Relevant Tickets

[ch6993]
https://app.clubhouse.io/rockets/story/6993/some-items-appear-indented-when-added-to-bag
