### PR TITLE
[ch7010] Make gray spinner a darker gray

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.463",
+  "version": "0.1.464",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.463",
+  "version": "0.1.464",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/core/icons/Spinner/GraySpinner.js
+++ b/src/core/icons/Spinner/GraySpinner.js
@@ -4,7 +4,7 @@ import Spinner from './Spinner.base'
 
 const GraySpinner = styled(Spinner)`
   rect {
-    fill: ${props => props.theme.colors.loading};
+    fill: ${props => props.theme.colors.gray7};
   }
 `
 

--- a/src/core/theme/colors.js
+++ b/src/core/theme/colors.js
@@ -35,6 +35,7 @@ const supportingColors = {
   gray4: '#D5D5D5',
   gray5: '#CFCFCF',
   gray6: '#979797',
+  gray7: '#6e6e6e',
   gray: [
     '#F3F3F3',
     '#F5F5F5',
@@ -42,7 +43,8 @@ const supportingColors = {
     '#E6E6E6',
     '#D5D5D5',
     '#CFCFCF',
-    '#979797'
+    '#979797',
+    '#6e6e6e'
   ],
   shadyLady: '#979797',
   red: '#FF511C',


### PR DESCRIPTION
#### What does this PR do?

Makes the GraySpinner a darker gray color for visibility when changing size and quantity of line items (in checkout and bag).

We are not actively using the GraySpinner anywhere on the site, so I made the color change to this existing component.

#### Relevant Tickets

[ch7010]
https://app.clubhouse.io/rockets/story/7010/customer-sees-darker-loading-indicator-when-changing-size-or-quantity