### PR TITLE
Fix FlexRow warnings and align functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.467",
+  "version": "0.1.468",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.467",
+  "version": "0.1.468",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/core/grid/flexCol.js
+++ b/src/core/grid/flexCol.js
@@ -22,8 +22,6 @@ const spanner = (props, breakpoint) => {
   }
 }
 
-
-
 const FlexCol = styled(BaseFlexCol)`
   box-sizing: border-box;
   max-width: ${props => props.mobile.nested

--- a/src/core/grid/flexRow.base.js
+++ b/src/core/grid/flexRow.base.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 const BaseFlexRow = ({ children, element, ...props }) => {
   delete props.constrained
   delete props.padding
+  delete props.align
   return React.createElement(element, props, children)
 }
 

--- a/src/core/grid/flexRow.js
+++ b/src/core/grid/flexRow.js
@@ -30,9 +30,9 @@ const FlexRow = styled(BaseFlexRow)`
   flex-basis: 100%;
   display: flex;
   flex-wrap: wrap;
+  justify-content: ${props => props.align};
   ${props => props.constrained ? constrained : notConstrained}
   ${props => props.padding && padding}
-  align-content: ${props => props.align}
 `
 
 FlexRow.propTypes = {
@@ -41,7 +41,8 @@ FlexRow.propTypes = {
     PropTypes.object
   ]),
   constrained: PropTypes.bool,
-  padding: PropTypes.bool
+  padding: PropTypes.bool,
+  align: PropTypes.string
 }
 
 FlexRow.defaultProps = {


### PR DESCRIPTION
#### What does this PR do?
With this change we'll fix a couple of warnings thrown when using the `FlexRow` component and make sure that the align
property works as expected.
