### PR TITLE
Fix link styling and warnings related to the FlexCol component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.468",
+  "version": "0.1.469",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.468",
+  "version": "0.1.469",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/core/grid/flexCol.base.js
+++ b/src/core/grid/flexCol.base.js
@@ -7,6 +7,8 @@ const BaseFlexCol = ({ element, children, key, ...props}) => {
   delete props.mobile
   delete props.tablet
   delete props.nested
+  delete props.gutter
+
   return React.createElement(element, props, children)
 }
 

--- a/src/core/grid/flexRow.base.js
+++ b/src/core/grid/flexRow.base.js
@@ -5,6 +5,7 @@ const BaseFlexRow = ({ children, element, ...props }) => {
   delete props.constrained
   delete props.padding
   delete props.align
+
   return React.createElement(element, props, children)
 }
 

--- a/src/core/typography/link/Link.base.js
+++ b/src/core/typography/link/Link.base.js
@@ -14,6 +14,12 @@ const baseLinkStyles = css`
   font-size: ${props => props.fontSize};
   font-weight: ${props => props.light ? '400' : props.fontWeight};
   font-style: ${props => props.fontStyle};
+
+  &:active,
+  &:focus,
+  &:hover {
+    text-decoration: none;
+  }
 `
 
 const BaseLink = styled(({ renderLink, children, ...props }) => {


### PR DESCRIPTION
#### What does this PR do?
With this change we'll make sure that `Links` are not underlined when they are hovered, this was being added by the default
bootstrap styles which are still present in some of the quark-ui pages.

This change will also fix some warnings associated with the FlexCol component.