### PR TITLE
[ch7664] Fix above media query to be larger max width than the selected device

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.469",
+  "version": "0.1.470",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.469",
+  "version": "0.1.470",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/core/theme/mediaQueries.js
+++ b/src/core/theme/mediaQueries.js
@@ -1,7 +1,7 @@
 import { css } from 'styled-components'
 
 const sizes = {
-  phone: 321,
+  phone: 320,
   phoneMax: 414,
   tablet: 768,
   mobileNav: 889,
@@ -19,7 +19,7 @@ Object.keys(sizes).forEach((label) => {
   breakpoints[`below${label.charAt(0).toUpperCase()}${label.substr(1)}`] =
   `(max-width: ${sizes[label] - 1}px)`
   breakpoints[`above${label.charAt(0).toUpperCase()}${label.substr(1)}`] =
-  `(min-width: ${sizes[label]}px)`
+  `(min-width: ${sizes[label] + 1}px)`
 })
 
 export { breakpoints, sizes }

--- a/src/core/typography/H1.test.js
+++ b/src/core/typography/H1.test.js
@@ -47,7 +47,7 @@ describe('(Styled Component) H1', () => {
     expect(createH1({ fontSizes: { desktop: '3.2rem', mobile: '2.4rem' } }))
     .toHaveStyleRule(
       'font-size', '3.2rem', {
-        media: '(min-width: 768px)'
+        media: '(min-width: 769px)'
       }
     )
   })
@@ -56,7 +56,7 @@ describe('(Styled Component) H1', () => {
     expect(createH1({ lineHeights: { desktop: 2, mobile: 1.5 } }))
     .toHaveStyleRule(
       'line-height', `${2}`, {
-        media: '(min-width: 768px)'
+        media: '(min-width: 769px)'
       }
     )
   })


### PR DESCRIPTION
#### What does this PR do?

`FlexRow` uses different margins for `abovePhoneMax` media query. This commit fixes the `above` queries to only include wider widths than the device size. So `abovePhoneMax` will not include phones with the widest 414px width.

This previously caused issues where iPhone plus devices could show styling meant for larger devices.

#### Relevant Tickets

[ch7664]
https://app.clubhouse.io/rockets/story/7664/existing-subscribers-see-new-page-to-change-their-box-sizes
