### PR TITLE
Update the children prop type for heading elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.472",
+  "version": "0.1.473",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.472",
+  "version": "0.1.473",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/header/desktopHeader/headerLink/headerLink.js
+++ b/src/components/header/desktopHeader/headerLink/headerLink.js
@@ -52,11 +52,7 @@ HeaderLink.defaultProps = {
 HeaderLink.propTypes = {
   highlightable: PropTypes.bool,
   highlightOn: PropTypes.string,
-  children: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.object,
-    PropTypes.string
-  ])
+  children: PropTypes.node
 }
 
 export { BaseHeaderLink }

--- a/src/core/typography/H1.js
+++ b/src/core/typography/H1.js
@@ -33,11 +33,7 @@ H1.propTypes = {
     mobile: PropTypes.number
   }),
   margin: PropTypes.string,
-  children: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.string,
-    PropTypes.object
-  ]),
+  children: PropTypes.node,
   theme: PropTypes.shape({
     fonts: PropTypes.shape({
       headerFont: PropTypes.string

--- a/src/core/typography/H2.js
+++ b/src/core/typography/H2.js
@@ -20,11 +20,7 @@ const H2 = styled.h2`
 `
 H2.propTypes = {
   center: PropTypes.bool,
-  children: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.string,
-    PropTypes.object
-  ]),
+  children: PropTypes.node,
   theme: PropTypes.shape({
     fonts: PropTypes.shape({
       headerFont: PropTypes.string

--- a/src/core/typography/H3.js
+++ b/src/core/typography/H3.js
@@ -17,11 +17,7 @@ const H3 = styled.h3`
 `
 
 H3.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.string,
-    PropTypes.object
-  ]),
+  children: PropTypes.node,
   theme: PropTypes.shape({
     fonts: PropTypes.shape({
       headerFont: PropTypes.string

--- a/src/core/typography/H4.js
+++ b/src/core/typography/H4.js
@@ -17,11 +17,7 @@ const H4 = styled.h4`
 `
 
 H4.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.string,
-    PropTypes.object
-  ]),
+  children: PropTypes.node,
   theme: PropTypes.shape({
     fonts: PropTypes.shape({
       primaryFont: PropTypes.string

--- a/src/core/typography/H5.js
+++ b/src/core/typography/H5.js
@@ -17,11 +17,7 @@ const H5 = styled.h5`
 `
 
 H5.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.string,
-    PropTypes.object
-  ]),
+  children: PropTypes.node,
   theme: PropTypes.shape({
     fonts: PropTypes.shape({
       primaryFont: PropTypes.string

--- a/src/core/typography/H6.js
+++ b/src/core/typography/H6.js
@@ -16,11 +16,7 @@ const H6 = styled.h6`
 `
 
 H6.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.string,
-    PropTypes.object
-  ]),
+  children: PropTypes.node,
   theme: PropTypes.shape({
     fonts: PropTypes.shape({
       primaryFont: PropTypes.string

--- a/src/core/typography/Label.js
+++ b/src/core/typography/Label.js
@@ -35,11 +35,7 @@ const LowercaseLabel = ({className, children}) => {
 }
 
 Label.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.object,
-    PropTypes.string
-  ]),
+  children: PropTypes.node,
   theme: PropTypes.shape({
     fonts: PropTypes.shape({
       primaryFont: PropTypes.string


### PR DESCRIPTION
#### What does this PR do?
With this change we'll update the prop type of the children property passed to heading elements to be PropTypes.node as
it allows a lot more flexibility and suits it better.