### PR TITLE
Ensure button links are compatible with Bootstrap styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.474",
+  "version": "0.1.475",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.474",
+  "version": "0.1.475",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/inputs/Buttons/Button/ButtonLink.js
+++ b/src/components/inputs/Buttons/Button/ButtonLink.js
@@ -55,6 +55,12 @@ const ButtonLink = styled(BaseButtonLink)`
   line-height: 44px;
   text-decoration: none;
   ${props => props.maxWidth && setMaxWidth}
+
+  &:focus,
+  &:hover {
+    color: ${textColor};
+    text-decoration: none;
+  }
 `
 /** @component */
 export default ButtonLink


### PR DESCRIPTION
#### What does this PR do?
With this change we'll make sure that ButtonLinks don't change their styling when hovering over them in quark-ui. Since
it's still using Bootstrap in certain parts of the application, our ButtonLinks are changing color when the user hovers over them, which is not what we want.