### PR TITLE
Add navigation links for /rockets-reverse on desktop and mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.476",
+  "version": "0.1.477",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.476",
+  "version": "0.1.477",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/header/desktopHeader/accountLinks/subMenu.js
+++ b/src/components/header/desktopHeader/accountLinks/subMenu.js
@@ -65,9 +65,9 @@ export class BaseSubMenu extends React.Component {
                 <Link
                   uppercase
                   underline={false}
-                  target='/rockets-reverse'
+                  target='/reverse'
                   renderLink={renderLink}
-                  className={pathname === '/rockets-reverse' && 'highlighted'}
+                  className={pathname === '/reverse' && 'highlighted'}
                 >
                   Rockets Reverse
                 </Link>

--- a/src/components/header/desktopHeader/accountLinks/subMenu.js
+++ b/src/components/header/desktopHeader/accountLinks/subMenu.js
@@ -37,7 +37,7 @@ z-index: 10;
 
 export class BaseSubMenu extends React.Component {
   render () {
-    const { className, childCount, open, signOut, isSubscriptionMember, renderLink } = this.props
+    const { className, childCount, open, signOut, isSubscriptionMember, renderLink, pathname } = this.props
     return (
       <CSSTransitionGroup
         transitionName={transition}
@@ -62,6 +62,15 @@ export class BaseSubMenu extends React.Component {
                   renderLink={renderLink}>
                   Manage Deliveries
                 </Link>
+                <Link
+                  uppercase
+                  underline={false}
+                  target='/rockets-reverse'
+                  renderLink={renderLink}
+                  className={pathname === '/rockets-reverse' && 'highlighted'}
+                >
+                  Rockets Reverse
+                </Link>
               </div>
             }
             <Link
@@ -85,6 +94,15 @@ export class BaseSubMenu extends React.Component {
                 target='/add-kid'
                 renderLink={renderLink}>
                 Add a Child
+              </Link>
+            }
+            {isSubscriptionMember &&
+              <Link
+                uppercase
+                underline={false}
+                target='/invite'
+                renderLink={renderLink}>
+                Refer a Friend
               </Link>
             }
             <Link
@@ -121,6 +139,11 @@ const SubMenu = styled(BaseSubMenu)`
       }
     }
 
+  .highlighted {
+    background-color: ${props => props.theme.colors.rocketBlue};
+    color: ${props => props.theme.colors.white};
+  }
+
   .enter {
     z-index: 4;
     animation: ${slideDown} 0.25s;
@@ -136,10 +159,10 @@ const SubMenu = styled(BaseSubMenu)`
 
 SubMenu.propTypes = {
   open: PropTypes.bool,
-  currentPath: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   signOut: PropTypes.func,
   childCount: PropTypes.number,
-  isSubscriptionMember: PropTypes.bool
+  isSubscriptionMember: PropTypes.bool,
+  pathname: PropTypes.string
 }
 
 SubMenu.defaultProps = {

--- a/src/modules/header/desktopNavigation/accountLinks/desktopAccountLinks.js
+++ b/src/modules/header/desktopNavigation/accountLinks/desktopAccountLinks.js
@@ -31,6 +31,7 @@ export class BaseAccountLinks extends React.Component {
       loggedIn,
       renderLink,
       name,
+      pathname,
       ...props
     } = this.props
     delete props.subMenuOpen
@@ -52,6 +53,7 @@ export class BaseAccountLinks extends React.Component {
             renderLink={renderLink}
             isSubscriptionMember={isSubscriptionMember}
             signOut={this.signOut}
+            pathname={pathname}
             {...props} />
           </div>
       )

--- a/src/modules/header/desktopNavigation/accountLinks/desktopAccountLinks.test.js
+++ b/src/modules/header/desktopNavigation/accountLinks/desktopAccountLinks.test.js
@@ -2,7 +2,6 @@ import React from 'react'
 import 'jest-styled-components'
 
 import { DesktopAccountLinks, Link, HeaderLink, SubMenu } from 'SRC'
-import { BaseDesktopAccountLinks } from './desktopAccountLinks'
 
 const { mountWithTheme } = global
 
@@ -89,7 +88,7 @@ describe('(Styled Component) DesktopAccountLinks', () => {
         .find(SubMenu)
         .find(Link)
         .length
-      ).toEqual(6)
+      ).toEqual(8)
     })
 
   })

--- a/src/modules/header/desktopNavigation/desktopNavigation.js
+++ b/src/modules/header/desktopNavigation/desktopNavigation.js
@@ -70,6 +70,7 @@ export class BaseDesktopNavigation extends React.Component {
       clickSearch,
       showBlog,
       showSearch,
+      pathname,
       ...props
     } = this.props
     const {
@@ -207,6 +208,7 @@ export class BaseDesktopNavigation extends React.Component {
                     isSubscriptionMember={isSubscriptionMember}
                     highlightable={highlightable}
                     renderLink={renderLink}
+                    pathname={pathname}
                     {...props} />
                 </li>
                 <li>

--- a/src/modules/header/mobileNavigation/mobileNavigation.js
+++ b/src/modules/header/mobileNavigation/mobileNavigation.js
@@ -160,25 +160,32 @@ export class BaseMobileNavigation extends React.Component {
             }
             {isSubscriptionMember &&
               <div>
-              <li>
-                <MobileLinkTop
-                  href={`${homepageUrl}/shop/sale`}>
-                  Sale
-                </MobileLinkTop>
-              </li>
-              <li>
-                <MobileLinkTop
-                  target='/box'
-                  renderLink={renderLink}>
-                  Box
-                </MobileLinkTop>
-              </li>
+                <li>
+                  <MobileLinkTop
+                    href={`${homepageUrl}/shop/sale`}>
+                    Sale
+                  </MobileLinkTop>
+                </li>
+                <li>
+                  <MobileLinkTop
+                    target='/box'
+                    renderLink={renderLink}>
+                    Box
+                  </MobileLinkTop>
+                </li>
                 <li>
                   <MobileLinkTop
                     target='/invite'
                     renderLink={renderLink}
                     background={theme.colors.lightPink}>
-                    Free Clothes
+                    Refer a Friend
+                  </MobileLinkTop>
+                </li>
+                <li>
+                  <MobileLinkTop
+                    target='/rockets-reverse'
+                    renderLink={renderLink}>
+                    Rockets Reverse
                   </MobileLinkTop>
                 </li>
                 <li>

--- a/src/modules/header/mobileNavigation/mobileNavigation.js
+++ b/src/modules/header/mobileNavigation/mobileNavigation.js
@@ -183,7 +183,7 @@ export class BaseMobileNavigation extends React.Component {
                 </li>
                 <li>
                   <MobileLinkTop
-                    target='/rockets-reverse'
+                    target='/reverse'
                     renderLink={renderLink}>
                     Rockets Reverse
                   </MobileLinkTop>


### PR DESCRIPTION
#### What does this PR do?

Adds "Rockets Reverse" link to desktop and mobile navigation on Thor pages.

#### PR Dependencies

PR on Quark UI

#### Relevant Tickets

[ch7841]
https://app.clubhouse.io/rockets/story/7841/subscriber-sees-rockets-reverse-in-nav-on-mobile

[ch7843]
https://app.clubhouse.io/rockets/story/7843/subscriber-sees-rockets-reverse-in-nav-on-desktop

