### PR TITLE
Ch7902 instagram feed homepage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.479",
+  "version": "0.1.480",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.479",
+  "version": "0.1.480",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/social-media/instagram.js
+++ b/src/components/social-media/instagram.js
@@ -2,96 +2,30 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import MediaQuery from 'react-responsive'
 import styled, { withTheme } from 'styled-components'
-import Slider from 'react-slick'
-import Instafeed from 'instafeed.js'
-
 import { InlineImage } from 'SRC'
 
-const { REACT_APP_INSTAGRAM_ACCESS_TOKEN, REACT_APP_INSTAGRAM_CLIENT_ID, REACT_APP_INSTAGRAM_USER_ID } = process.env
-
 class BaseInstagram extends React.Component {
-  _isMounted = false;
-
-  constructor(props) {
-    super(props);
-    this.instagramRef = null
-
-    this.config = {
-      infinite: false,
-      arrows: false,
-      className: 'slider',
-      centerMode: true,
-      slidesToShow: 1,
-      variableWidth: true
-    }
-    this.state = {
-      instagramLoading: true,
-      instagramPictures: []
-    }
-  }
-
-  componentDidMount () {
-    this._isMounted = true
-    const { limit, clientId, userId, accessToken } = this.props
-
-    try {
-      if (clientId && userId && accessToken) {
-        this.feed = new Instafeed({
-          get: 'user',
-          target: this.instagramRef,
-          clientId: clientId,
-          userId: userId,
-          accessToken: accessToken,
-          resolution: 'standard_resolution',
-          limit: limit,
-          template: '<a class="image-link" aria-label="{{caption}}" href="{{link}}"><img src="{{image}}" aria-hidden /></a>',
-          success: (args) => {
-            this.setInstragramPics(args)
-          }
-        }).run()
-      }
-    } catch(error) {
-      console.error(`error: ${error}`)
-    }
-  }
-
-  componentWillUnmount () {
-    this._isMounted = false
-  }
-
-  setInstragramPics = (args) => {
-    if (this._isMounted) {
-      this.setState({instagramLoading: false, instagramPictures: args.data})
-    }
-  }
-
-  setInstagramRef = (element) => {
-    this.instagramRef = element
-  }
 
   render () {
     const { className, theme } = this.props
-    const { instagramLoading, instagramPictures } = this.state
     return (
       <div className={className}>
         <MediaQuery query={theme.breakpoints.aboveTabletMax}>
-          <section className='desktopContainer' ref={this.setInstagramRef}>
+          <section className='desktopContainer'>
             <InlineImage aria-hidden className='gif' alt='Fun and animated illustration of phone and Instagram photo' src='https://d2lknnt52h7uhg.cloudfront.net/roa-canon/image/upload/v1563995547/web/PHONE_STATIC.png' />
           </section>
         </MediaQuery>
         <MediaQuery query="(max-device-width: 959px)">
           <div className='mobileContainer'>
-            {!instagramLoading && <Slider {...this.config}>
-              {instagramPictures.map((imageObject, i) => {
-                return (<a key={`imageObject-${i}`} href={imageObject.link} target="_blank">
-                  <img className='mobileImg' src={imageObject.images.standard_resolution.url} alt='mobile instagram'/>
-                </a>)
-              })}
-            </Slider>}
             <InlineImage className='mobileGif' alt='Fun and animated illustration of phone and Instagram photo' src='https://d2lknnt52h7uhg.cloudfront.net/roa-canon/image/upload/v1563995547/web/PHONE_STATIC.png' />
-            <div ref={this.setInstagramRef} style={{display: 'none'}} aria-hidden />
           </div>
         </MediaQuery>
+        <div className="gallery-container">
+          <div
+            className="yotpo yotpo-pictures-widget"
+            data-gallery-id="5f8f01c819d86f05c671703e">
+          </div>
+        </div>
       </div>
     )
   }
@@ -99,6 +33,10 @@ class BaseInstagram extends React.Component {
 
 const Instagram = styled(BaseInstagram)`
   width: 100%;
+  padding: 0 2rem;
+  ${props => props.theme.breakpointsVerbose.belowTablet`
+    display: block !important;
+  `}
   .desktopContainer {
     display: flex;
     flex-wrap: wrap;
@@ -115,8 +53,8 @@ const Instagram = styled(BaseInstagram)`
     }
     .gif {
       height: 260px;
-      margin-right: -50px;
       z-index: 0;
+      padding-left: 5px;
     }
   }
   .mobileContainer {
@@ -126,12 +64,21 @@ const Instagram = styled(BaseInstagram)`
     justify-content: center;
     align-items: center;
     position: relative;
+    ${props => props.theme.breakpointsVerbose.belowTablet`
+      display: block;
+      text-align: center;
+      margin-bottom: 20px;
+    `}
   }
   .mobileGif {
     width: 14rem;
     left: 0;
     position: absolute;
     padding-left: 5px;
+    ${props => props.theme.breakpointsVerbose.belowTablet`
+      position: relative;
+      padding-left: 0;
+    `}
   }
   .mobileImg {
     width: 20rem;
@@ -150,21 +97,21 @@ const Instagram = styled(BaseInstagram)`
   .image-link {
     font-size: 0px;
   }
+  .gallery-container {
+    ${props => props.theme.breakpointsVerbose.aboveLaptop`
+      padding-left: 5px;
+    `}
+    ${props => props.theme.breakpointsVerbose.belowLaptop`
+      margin-left: 14rem;
+    `}
+    ${props => props.theme.breakpointsVerbose.belowTablet`
+      margin-left: 0;
+    `}
+  }
 `
 
 Instagram.propTypes = {
-  limit: PropTypes.number,
-  clientId: PropTypes.string,
-  userId: PropTypes.string,
-  accessToken: PropTypes.string,
   theme: PropTypes.object
-}
-
-Instagram.defaultProps = {
-  limit: 4,
-  clientId: REACT_APP_INSTAGRAM_CLIENT_ID,
-  userId: REACT_APP_INSTAGRAM_USER_ID,
-  accessToken: REACT_APP_INSTAGRAM_ACCESS_TOKEN
 }
 
 /** @component */

--- a/src/components/social-media/instagram.js
+++ b/src/components/social-media/instagram.js
@@ -1,25 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import MediaQuery from 'react-responsive'
 import styled, { withTheme } from 'styled-components'
 import { InlineImage } from 'SRC'
 
 class BaseInstagram extends React.Component {
-
   render () {
-    const { className, theme } = this.props
+    const { className } = this.props
     return (
       <div className={className}>
-        <MediaQuery query={theme.breakpoints.aboveTabletMax}>
-          <section className='desktopContainer'>
-            <InlineImage aria-hidden className='gif' alt='Fun and animated illustration of phone and Instagram photo' src='https://d2lknnt52h7uhg.cloudfront.net/roa-canon/image/upload/v1563995547/web/PHONE_STATIC.png' />
-          </section>
-        </MediaQuery>
-        <MediaQuery query="(max-device-width: 959px)">
-          <div className='mobileContainer'>
-            <InlineImage className='mobileGif' alt='Fun and animated illustration of phone and Instagram photo' src='https://d2lknnt52h7uhg.cloudfront.net/roa-canon/image/upload/v1563995547/web/PHONE_STATIC.png' />
-          </div>
-        </MediaQuery>
+        <div className='gifContainer'>
+          <InlineImage aria-hidden className='gif' alt='Fun and animated illustration of phone and Instagram photo' src='https://d2lknnt52h7uhg.cloudfront.net/roa-canon/image/upload/v1563995547/web/PHONE_STATIC.png' />
+        </div>
         <div className="gallery-container">
           <div
             className="yotpo yotpo-pictures-widget"
@@ -37,7 +28,7 @@ const Instagram = styled(BaseInstagram)`
   ${props => props.theme.breakpointsVerbose.belowTablet`
     display: block !important;
   `}
-  .desktopContainer {
+  .gifContainer {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
@@ -55,50 +46,34 @@ const Instagram = styled(BaseInstagram)`
       height: 260px;
       z-index: 0;
       padding-left: 5px;
+      ${props => props.theme.breakpointsVerbose.belowTabletMax`
+        width: 14rem;
+        height: auto;
+        left: 0;
+        position: absolute;
+      `}
+      ${props => props.theme.breakpointsVerbose.belowTablet`
+        position: relative;
+        padding-left: 0;
+      `}
     }
-  }
-  .mobileContainer {
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    position: relative;
+
+    ${props => props.theme.breakpointsVerbose.belowTabletMax`
+      width: 100%;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+      position: relative;
+    `}
+
     ${props => props.theme.breakpointsVerbose.belowTablet`
       display: block;
       text-align: center;
       margin-bottom: 20px;
     `}
   }
-  .mobileGif {
-    width: 14rem;
-    left: 0;
-    position: absolute;
-    padding-left: 5px;
-    ${props => props.theme.breakpointsVerbose.belowTablet`
-      position: relative;
-      padding-left: 0;
-    `}
-  }
-  .mobileImg {
-    width: 20rem;
-  }
-  .slider {
-    overflow: hidden;
-    > div > div {
-      display: flex;
-    }
-    .slick-slide {
-      display: flex;
-      justify-content: center;
-      padding-right: 20px;
-    }
-  }
-  .image-link {
-    font-size: 0px;
-  }
   .gallery-container {
-    ${props => props.theme.breakpointsVerbose.aboveLaptop`
+    ${props => props.theme.breakpointsVerbose.aboveIncludingLaptop`
       padding-left: 5px;
     `}
     ${props => props.theme.breakpointsVerbose.belowLaptop`


### PR DESCRIPTION
#### What does this PR do?
This PR adds the Yotpo Instagram carousel to the shop homepage in place of the broken Instagram feed.

#### Screenshots
![Screen Shot 2020-10-28 at 4 39 38 PM](https://user-images.githubusercontent.com/43832282/97494048-3140e200-193c-11eb-9156-84822db9f33f.png)

#### Relevant Tickets
[ch7902]
https://app.clubhouse.io/rockets/story/7902/customers-see-instagram-photos-on-shop-landing-page-again