### PR TITLE
Use separate Yotpo gallery for the shop homepage and increase padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.482",
+  "version": "0.1.483",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.482",
+  "version": "0.1.483",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/social-media/instagram.js
+++ b/src/components/social-media/instagram.js
@@ -14,7 +14,7 @@ class BaseInstagram extends React.Component {
         <div className="gallery-container">
           <div
             className="yotpo yotpo-pictures-widget"
-            data-gallery-id="5f8f01c819d86f05c671703e">
+            data-gallery-id="5fa029c167e297000789c89b">
           </div>
         </div>
       </div>
@@ -24,9 +24,10 @@ class BaseInstagram extends React.Component {
 
 const Instagram = styled(BaseInstagram)`
   width: 100%;
-  padding: 0 2rem;
+  padding: 0 7%;
   ${props => props.theme.breakpointsVerbose.belowTablet`
     display: block !important;
+    padding: 0 2rem;
   `}
   .gifContainer {
     display: flex;


### PR DESCRIPTION
#### What does this PR do?
This commit will assign the shop homepage a different Yotpo Instagram photo gallery from the gallery that is on the subscription homepage. This way we will be able to make visual adjustments to the galleries separately via the Yotpo dashboard.

We are also increasing padding around the Instagram feed on larger screen sizes.

#### Relevant Tickets
https://app.clubhouse.io/rockets/story/7902/customers-see-instagram-photos-on-shop-landing-page-again