### PR TITLE
[ch7949] Display out of stock and not enough quantity error messages in red

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.481",
+  "version": "0.1.482",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.481",
+  "version": "0.1.482",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.js
+++ b/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.js
@@ -89,7 +89,7 @@ const Attribute = styled.div`
   font-size: 14px;
   font-weight: normal;
   font-family: ${props => props.theme.fonts.primaryFont};
-  color: ${props => props.theme.colors.navy};
+  color: ${props => props.red ? props.theme.colors.red : props.theme.colors.navy};
 
   em {
     margin-left: 6px;
@@ -270,7 +270,7 @@ class BaseProduct extends React.Component {
             </Attribute>
           }
           {(item.not_enough_quantity_error || isOutOfStock) &&
-            <Attribute>
+            <Attribute red={true}>
               {this.getNotEnoughQuantityError()}
             </Attribute>
           }


### PR DESCRIPTION
#### What does this PR do?
This PR changes the color of product error messages in the persistent cart. "Out of stock." and "Only x items left" will be displayed in red so they are more noticeable to the customer.

#### Screenshots
![Screen Shot 2020-11-16 at 5 33 49 PM](https://user-images.githubusercontent.com/43832282/99316191-e8d95d80-2831-11eb-94ef-3b07d13a87fc.png)

#### Relevant Tickets
 https://app.clubhouse.io/rockets/story/7949/ecomm-customer-understands-why-they-can-t-check-out
