### PR TITLE
[ch8027] Show original price on PDPs with  sale items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.485",
+  "version": "0.1.486",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.485",
+  "version": "0.1.486",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/productTitle/ProductTitle.js
+++ b/src/components/productTitle/ProductTitle.js
@@ -54,8 +54,8 @@ const ProductTitle = ({
   evergreenPromoItemCount,
   evergreenPromoPercent
 }) => {
-  const originalPrice = currentVariant.original_price
-  const price = currentVariant.price
+  const originalPrice = Number(currentVariant.original_price)
+  const price = Number(currentVariant.price)
   const onSale = originalPrice && price < originalPrice
   const percent = (100 - parseInt(evergreenPromoPercent, 10)) / 100
   const promoPrice = price * percent


### PR DESCRIPTION
#### What does this PR do?
This PR solves an issue where we were evaluating whether a price is less than the original price to confirm it's on sale, but because the prices were strings the logic was sometimes faulty. We are now converting to numbers before using any operators.

example for $5 sale items: "5.0" < "19.5" returns false, but we want to confirm that $5 is less than $19.50

#### Relevant Tickets
https://app.clubhouse.io/rockets/story/8027/pdps-of-5-bonanza-items-should-show-full-price-discount
