### PR TITLE
[ch8025] Adjust z-index of header to work with Yotpo Instagram widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.484",
+  "version": "0.1.485",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.484",
+  "version": "0.1.485",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/header/header.js
+++ b/src/modules/header/header.js
@@ -54,7 +54,7 @@ class BaseHeader extends Component {
 
 const Header = styled(BaseHeader)`
   position: ${props => props.position};
-  z-index: 4;
+  z-index: 50;
   width: 100%;
 `
 

--- a/src/modules/searchModal/searchModal.js
+++ b/src/modules/searchModal/searchModal.js
@@ -11,7 +11,7 @@ const SearchDiv = styled.div`
 `
 
 const SearchBarDiv = styled.div`
-  z-index: 5;
+  z-index: 51;
   position: fixed;
   top: 0;
   left: 0;
@@ -26,7 +26,7 @@ const SearchBarDiv = styled.div`
 `
 
 const SearchModalDiv = styled.div`
-  z-index: 4;
+  z-index: 50;
   position: fixed;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
#### What does this PR do?
This PR prevents the Yotpo Instagram widget arrows from overlapping the header and dropdown menu.

#### Relevant Tickets
https://app.clubhouse.io/rockets/story/8025/shop-landing-page-instagram-module-overlaps-with-mobile-hamburger-menu