### PR TITLE
Ensure that images on the ProductTile slider match the current colorway

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.487",
+  "version": "0.1.488",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.487",
+  "version": "0.1.488",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/images/slider/slider.base.js
+++ b/src/components/images/slider/slider.base.js
@@ -67,10 +67,10 @@ export class BaseROASlider extends Component {
           ref={this.setSlider}
           {...this.config}
         >
-          {images.map((image, index) => {
+          {images.map((image) => {
             if (renderLink && target) {
               return (
-                <Link target={target} key={index}>
+                <Link target={target} key={image.src}>
                   <InlineImage
                     alt={image.alt}
                     src={image.src}
@@ -81,7 +81,7 @@ export class BaseROASlider extends Component {
             } else {
               return (
                 <InlineImage
-                  key={index}
+                  key={image.src}
                   alt={image.alt}
                   src={image.src}
                   onClick={onClick}

--- a/src/modules/productTile/productTile.base.js
+++ b/src/modules/productTile/productTile.base.js
@@ -88,13 +88,20 @@ export default class ProductTile extends React.Component {
       renderLink,
       evergreenPromoItemCount,
       evergreenPromoPercent,
-      ...props
+      sliderLazyLoad,
     } = this.props
+
     const { selectedColorway, lazyLoad } = this.state
     const colorway = this.getSelectedColorway()
     const target = this.getUrl()
     const Link = renderLink
-    const sharedSliderProps = { product, shots: colorway.shots, lazyLoad, ...props }
+    const sharedSliderProps = {
+      product,
+      shots: colorway.shots,
+      lazyLoad,
+      sliderLazyLoad
+    }
+
     return (
       <div className={className}>
         <AboveLaptopSlider>


### PR DESCRIPTION
#### What does this PR do?
With this change we'll make sure that images in the `ProductTile` slider match the currently selected colorway. Basically the image wouldn't change before because we were spreading all of the props from ProductTile and passing them to the Slider, which caused the `lazyLoad` prop to override the value of the `lazyLoad` key coming from `state`.

Since `lazyLoad` was true, we were attempting to lazy load the images for the newly selected colorway, which would only happen if the user scrolled. With this change we'll stop spreading props and passing them to the Slider which should make it obvious which properties it's receiving at any point in time and fix the bug.

#### Relevant Tickets
https://app.clubhouse.io/rockets/story/7385/desktop-customer-can-t-view-additional-colorway-photo-on-select-items
