### PR TITLE
[ch7695] Allow customers checking out with Apple Pay to select from a…

### DIFF
--- a/src/components/paymentRequestForm/paymentRequestForm.js
+++ b/src/components/paymentRequestForm/paymentRequestForm.js
@@ -38,14 +38,12 @@ const buildShippingOptions = (order) => {
     shippingMethods = shippingMethods.sort((x,y) => x.id === selectedId ? -1 : y.id === selectedId ? 1 : 0 )
   }
 
-  return shippingMethods.map((method) => {
-    return ({
-      id: method.id.toString(),
-      label: method.name,
-      amount: Math.round(parseFloat(method.cost) * 100),
-      detail: `Delivered in ${method.lower_bound}-${method.upper_bound} business days`
-    })
-  })
+  return shippingMethods.map((method) => ({
+    id: method.id.toString(),
+    label: method.name,
+    amount: Math.round(parseFloat(method.cost) * 100),
+    detail: `Delivered in ${method.lower_bound}-${method.upper_bound} business days`
+  }))
 }
 
 const OrContainer = styled(P)`

--- a/src/components/paymentRequestForm/paymentRequestForm.js
+++ b/src/components/paymentRequestForm/paymentRequestForm.js
@@ -31,6 +31,23 @@ const buildDisplayItems = (order, pending) => {
   return displayItems
 }
 
+const buildShippingOptions = (order) => {
+  let shippingMethods = order.shipping_methods
+  if (order.selected_shipping_rate_id) {
+    const selectedId = order.selected_shipping_rate_id
+    shippingMethods = shippingMethods.sort((x,y) => x.id === selectedId ? -1 : y.id === selectedId ? 1 : 0 )
+  }
+
+  return shippingMethods.map((method) => {
+    return ({
+      id: method.id.toString(),
+      label: method.name,
+      amount: Math.round(parseFloat(method.cost) * 100),
+      detail: `Delivered in ${method.lower_bound}-${method.upper_bound} business days`
+    })
+  })
+}
+
 const OrContainer = styled(P)`
   margin: 0 10px;
 `
@@ -65,7 +82,7 @@ export class PaymentRequestForm extends React.Component {
   }
 
   createPaymentRequest = () => {
-    const { order, stripe, submitCheckout, setShippingAddress } = this.props
+    const { order, stripe, submitCheckout, setShippingAddress, setShippingMethod } = this.props
     const paymentRequest = stripe.paymentRequest({
       country: 'US',
       currency: 'usd',
@@ -103,32 +120,41 @@ export class PaymentRequestForm extends React.Component {
         default: false,
         email: this.props.currentUserEmail || 'guest@example.com'
       }
-
       if (shippingAddress.country !== 'US') {
         updateWith({status: 'invalid_shipping_address'})
       } else {
         try {
-          const order = await setShippingAddress(address)
-          const shippingMethod = order.shipping_methods[0]
+          const response = await setShippingAddress(address)
           updateWith({
             status: 'success',
             total: {
               label: 'Total',
-              amount: Math.round(parseFloat(order.total) * 100),
+              amount: Math.round(parseFloat(response.total) * 100),
               pending: false
             },
-            displayItems: buildDisplayItems(order, false),
-            shippingOptions: [
-              {
-                id: 'default',
-                label: shippingMethod.name,
-                amount: Math.round(parseFloat(shippingMethod.cost) * 100)
-              }
-            ]
+            displayItems: buildDisplayItems(response, false),
+            shippingOptions: buildShippingOptions(response)
           })
         } catch (error) {
           updateWith({status: 'fail'})
         }
+      }
+    })
+
+    paymentRequest.on('shippingoptionchange', async ({shippingOption, updateWith}) => {
+      try {
+        const response = await setShippingMethod(order.id, shippingOption.id)
+        updateWith({
+          status: 'success',
+          total: {
+            label: 'Total',
+            amount: Math.round(parseFloat(response.total) * 100),
+            pending: false
+          },
+          displayItems: buildDisplayItems(response, false)
+        })
+      } catch (error) {
+        updateWith({status: 'fail'})
       }
     })
 
@@ -168,6 +194,7 @@ PaymentRequestForm.propTypes = {
   stripe: PropTypes.object,
   order: PropTypes.object,
   setShippingAddress: PropTypes.func.isRequired,
+  setShippingMethod: PropTypes.func.isRequired,
   submitCheckout: PropTypes.func.isRequired,
   className: PropTypes.string,
   currentUserEmail: PropTypes.string,

--- a/src/modules/persistent-cart/cartSidebar/cartSidebar.js
+++ b/src/modules/persistent-cart/cartSidebar/cartSidebar.js
@@ -270,6 +270,7 @@ class BaseCartSidebar extends React.Component {
       segmentCartViewed,
       segmentProductRemoved,
       setShippingAddress,
+      setShippingMethod,
       shouldShowCartSidebar,
       subTotal,
       theme
@@ -379,6 +380,7 @@ class BaseCartSidebar extends React.Component {
                   currentUserEmail={currentUserEmail}
                   order={order}
                   setShippingAddress={setShippingAddress}
+                  setShippingMethod={setShippingMethod}
                   submitCheckout={this.submitCheckout}
                   onClickPaymentRequestButton={onClickPaymentRequestButton}
                 />
@@ -434,6 +436,7 @@ BaseCartSidebar.propTypes = {
   segmentCartViewed: PropTypes.func,
   segmentProductRemoved: PropTypes.func,
   setShippingAddress: PropTypes.func,
+  setShippingMethod: PropTypes.func,
   shouldShowCartSidebar: PropTypes.bool,
   submitBag: PropTypes.func,
   submitBagCheckoutStripe: PropTypes.func,


### PR DESCRIPTION
…ll available shipping methods

#### What does this PR do?
Allows customers checking out with Apple Pay/Google Pay to see and select from multiple shipping options. We were previously only allowing these orders to have standard shipping.

There is some logic included to make sure if the order already has a shipping method assigned (if they selected a faster shipping method in checkout and went back to bag for example) that method will be listed first as the default in the Apple Pay interface. Stripe/Apple Pay doesn't accept a pre-selected shipping method, but the default shipping method is the first in the `shippingOptions` array so this changes the order. This way if the customer will see the correct shipping method that would be used for their order if they don't change anything before confirming the payment.

#### Relevant Tickets
https://app.clubhouse.io/rockets/story/7695/apple-pay-customers-only-see-one-shipping-method
