### PR TITLE
Ensure datepickers update correctly when an initialValue is given

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.493",
+  "version": "0.1.494",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.493",
+  "version": "0.1.494",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/datepicker/Datepicker.js
+++ b/src/components/datepicker/Datepicker.js
@@ -121,8 +121,8 @@ class Datepicker extends React.Component {
   constructor(props) {
     super(props)
     this.state = { month: null }
-    this.components = {}
     this.blurred = {}
+    this.components = buildDefaultValues(props.initialValue)
 
     this.handleMonthChange = this.handleMonthChange.bind(this)
     this.handleChange = this.handleChange.bind(this)


### PR DESCRIPTION
#### What does this PR do?
With this change we'll fix a bug that prevented datepickers to pass the correct value to the `onChange` callback when an
`initialValue` had been given.