### PR TITLE
Add mini style option to button component

### DIFF
--- a/src/components/inputs/Buttons/Button/Button.js
+++ b/src/components/inputs/Buttons/Button/Button.js
@@ -5,12 +5,6 @@ import { WhiteSpinner } from 'SRC/core/icons/Spinner'
 import { WhiteCheckmark } from 'SRC/core/icons/Checkmark'
 import BaseButton from './Button.base'
 
-export const defaultStyle = css`
-  background-color: ${props => props.theme.colors.rocketBlue};
-  &:hover {
-    background-color: ${props => props.theme.colors.rocketBlueHover};
-  }
-`
 export const disabledOrLoading = css`
   background-color: ${props => props.theme.colors.loading};
 `
@@ -18,11 +12,36 @@ export const selected = css`
   background-color: ${props => props.theme.colors.navy}
 `
 
+const regularStyles = css`
+  background-color: ${props => props.theme.colors.rocketBlue};
+  &:hover {
+    background-color: ${props => props.theme.colors.rocketBlueHover};
+  }
+`
+
+const miniStyles = css`
+  border: 3px solid ${props => props.theme.colors.lightPink};
+  background-color: white;
+  color: ${props => props.theme.colors.rocketBlue};
+`
+
+const kindVariants = {
+  regular: regularStyles,
+  mini: miniStyles
+}
+
+function getBaseStyle (props) {
+  if (!props.selected && !props.disabled && !props.loading && !props.kind === 'mini') {
+    return regularStyles
+  } else if (props.kind === 'mini') {
+    return miniStyles
+  }
+}
+
 const backgroundColor = css`
-  ${props => (!props.selected && !props.disabled && !props.loading) && defaultStyle}
+  ${props => getBaseStyle(props)}
   ${props => props.selected && selected}
-  ${props => props.disabled && disabledOrLoading}
-  ${props => props.loading && disabledOrLoading}
+  ${props => (props.disabled || props.loading) && disabledOrLoading}
 `
 
 const blockStyles = css`
@@ -36,6 +55,7 @@ const Button = styled(BaseButton)`
 
   ${props => backgroundColor}
   ${props => props.block && blockStyles}
+  ${props => kindVariants[props.kind]}
 `
 
 Button.propTypes = {
@@ -53,15 +73,16 @@ Button.propTypes = {
       white: PropTypes.string
     })
   }),
-  block: PropTypes.bool
+  block: PropTypes.bool,
+  kind: PropTypes.string
 }
 
 Button.defaultProps = {
   checkmark: WhiteCheckmark,
   spinner: WhiteSpinner,
-  block: false
+  block: false,
+  kind: 'regular'
 }
-
 
 /** @component */
 export default Button

--- a/src/components/inputs/Buttons/Button/Button.js
+++ b/src/components/inputs/Buttons/Button/Button.js
@@ -12,8 +12,16 @@ export const selected = css`
   background-color: ${props => props.theme.colors.navy}
 `
 
+const backgroundColor = css`
+  ${props => (!props.selected && !props.disabled && !props.loading) && props.theme.colors.rocketBlue}
+  ${props => props.selected && selected}
+  ${props => (props.disabled || props.loading) && disabledOrLoading}
+`
+
 const regularStyles = css`
-  background-color: ${props => props.theme.colors.rocketBlue};
+  background-color: ${backgroundColor};
+  border-color: transparent;
+  color: ${props => props.theme.colors.white};
   &:hover {
     background-color: ${props => props.theme.colors.rocketBlueHover};
   }
@@ -30,32 +38,16 @@ const kindVariants = {
   mini: miniStyles
 }
 
-function getBaseStyle (props) {
-  if (!props.selected && !props.disabled && !props.loading && !props.kind === 'mini') {
-    return regularStyles
-  } else if (props.kind === 'mini') {
-    return miniStyles
-  }
-}
-
-const backgroundColor = css`
-  ${props => getBaseStyle(props)}
-  ${props => props.selected && selected}
-  ${props => (props.disabled || props.loading) && disabledOrLoading}
-`
-
 const blockStyles = css`
   width: 100%;
   display: block;
 `
 
 const Button = styled(BaseButton)`
-  color: ${props => props.theme.colors.white};
-  border-color: transparent;
-
-  ${props => backgroundColor}
-  ${props => props.block && blockStyles}
   ${props => kindVariants[props.kind]}
+  ${props => props.selected && selected}
+  ${props => (props.disabled || props.loading) && disabledOrLoading}
+  ${props => props.block && blockStyles}
 `
 
 Button.propTypes = {

--- a/src/components/inputs/Buttons/Button/Button.js
+++ b/src/components/inputs/Buttons/Button/Button.js
@@ -5,32 +5,32 @@ import { WhiteSpinner } from 'SRC/core/icons/Spinner'
 import { WhiteCheckmark } from 'SRC/core/icons/Checkmark'
 import BaseButton from './Button.base'
 
-export const disabledOrLoading = css`
-  background-color: ${props => props.theme.colors.loading};
-`
-export const selected = css`
-  background-color: ${props => props.theme.colors.navy}
-`
-
-const backgroundColor = css`
-  ${props => (!props.selected && !props.disabled && !props.loading) && props.theme.colors.rocketBlue}
-  ${props => props.selected && selected}
-  ${props => (props.disabled || props.loading) && disabledOrLoading}
-`
-
-const regularStyles = css`
-  background-color: ${backgroundColor};
-  border-color: transparent;
-  color: ${props => props.theme.colors.white};
+export const defaultRegularStyle = css`
+  background-color: ${props => props.theme.colors.rocketBlue};
   &:hover {
     background-color: ${props => props.theme.colors.rocketBlueHover};
   }
+`
+
+const regularStyles = css`
+  ${props => (!props.selected && !props.disabled && !props.loading) && defaultRegularStyle}
+  ${props => props.selected && selected}
+  ${props => props.disabled && disabledOrLoading}
+  border-color: transparent;
+  color: ${props => props.theme.colors.white};
 `
 
 const miniStyles = css`
   border: 3px solid ${props => props.theme.colors.lightPink};
   background-color: white;
   color: ${props => props.theme.colors.rocketBlue};
+`
+
+export const disabledOrLoading = css`
+  background-color: ${props => props.theme.colors.loading};
+`
+export const selected = css`
+  background-color: ${props => props.theme.colors.navy}
 `
 
 const kindVariants = {
@@ -45,8 +45,6 @@ const blockStyles = css`
 
 const Button = styled(BaseButton)`
   ${props => kindVariants[props.kind]}
-  ${props => props.selected && selected}
-  ${props => (props.disabled || props.loading) && disabledOrLoading}
   ${props => props.block && blockStyles}
 `
 

--- a/src/components/inputs/Buttons/Button/Button.md
+++ b/src/components/inputs/Buttons/Button/Button.md
@@ -20,3 +20,7 @@
 ```js
 <Button disabled width='150px'>Click Me!</Button>
 ```
+## Mini-Styled
+```js
+<Button kind='mini' width='150px'>Click Me!</Button>
+```


### PR DESCRIPTION
#### What does this PR do?
This PR adds the ability to toggle mini styling on our existing, non-input Button component. Trying to fit the `kind` prop into this component that was already using other props to manage styling felt kind of messy, so let me know if you think there's a cleaner solution here! This definitely feels like a good candidate for a refactor. 

#### Relevant Tickets
https://app.shortcut.com/rockets/story/9159/mini-quiz-age-or-stage-question-design-fixes