### PR TITLE
Add baby link to both desktop and mobile navigation

### DIFF
--- a/src/modules/header/desktopNavigation/desktopNavigation.js
+++ b/src/modules/header/desktopNavigation/desktopNavigation.js
@@ -135,6 +135,16 @@ export class BaseDesktopNavigation extends React.Component {
                   <HeaderLink
                     onMouseEnter={this.closeDrawers}
                     onFocus={this.closeDrawers}
+                    href='/shop/baby'
+                    highlightable={highlightable}
+                  >
+                    Baby
+                  </HeaderLink>
+                </li>
+                <li>
+                  <HeaderLink
+                    onMouseEnter={this.closeDrawers}
+                    onFocus={this.closeDrawers}
                     href={`${homepageUrl}/outfits`}
                     highlightable={highlightable}>
                       Outfits

--- a/src/modules/header/mobileNavigation/mobileNavigation.js
+++ b/src/modules/header/mobileNavigation/mobileNavigation.js
@@ -115,24 +115,29 @@ export class BaseMobileNavigation extends React.Component {
                   </Accordion>
                 </li>
                 <li>
-                <Accordion
-                  toggleElement={
-                    <MobileLinkSecondary>Girls</MobileLinkSecondary>
-                  }>
-                  <UL type='none' leftPad='1rem'>
-                  {girlsLinks && girlsLinks.map((link, index) => {
-                    return (
-                      <li key={index}>
-                        <MobileLinkTertiary
-                          target={link.target}
-                          renderLink={renderLink}>
-                          {link.text}
-                        </MobileLinkTertiary>
-                      </li>
-                    )
-                  })}
-                  </UL>
-                </Accordion>
+                  <Accordion
+                    toggleElement={
+                      <MobileLinkSecondary>Girls</MobileLinkSecondary>
+                    }>
+                    <UL type='none' leftPad='1rem'>
+                    {girlsLinks && girlsLinks.map((link, index) => {
+                      return (
+                        <li key={index}>
+                          <MobileLinkTertiary
+                            target={link.target}
+                            renderLink={renderLink}>
+                            {link.text}
+                          </MobileLinkTertiary>
+                        </li>
+                      )
+                    })}
+                    </UL>
+                  </Accordion>
+                </li>
+                <li>
+                  <MobileLinkSecondary target='/shop/baby' renderLink={renderLink}>
+                    Baby
+                  </MobileLinkSecondary>
                 </li>
               </UL>
             </li>


### PR DESCRIPTION
#### What does this PR do?
With this change we'll add a baby link to both the desktop and mobile navigation so customers can easily find the baby
PLP. In this first pass we'll just add a simple link we might want to add a dropdown with additional categories for mini
in the future.

#### Relevant Tickets
https://app.shortcut.com/rockets/story/9173/customers-can-navigate-to-baby-plp-from-shop-nav
