### PR TITLE
Add mini styling variant to regular select component

### DIFF
--- a/src/components/datepicker/Datepicker.js
+++ b/src/components/datepicker/Datepicker.js
@@ -38,7 +38,6 @@ function labelColor (props) {
   return props.theme.colors.navy
 }
 
-
 const Label = styled.label`
   display: block;
   font-size: 12px;
@@ -287,7 +286,7 @@ Datepicker.propTypes = {
   onChange: PropTypes.func.isRequired,
   onTouched: PropTypes.func,
   touched: PropTypes.bool,
-  yearOffset: PropTypes.number,
+  yearOffset: PropTypes.number
 }
 
 Datepicker.defaultProps = {

--- a/src/components/inputs/Select/Select.js
+++ b/src/components/inputs/Select/Select.js
@@ -1,30 +1,61 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import PropTypes from 'prop-types'
 
 import ErrorMessage from 'SRC/components/inputs/ErrorMessage'
 
-function borderColor(props) {
+function pickColor(props, color) {
   if (props.active) {
     return props.theme.colors.rocketBlue;
   } else if (props.error) {
     return props.theme.colors.flameOrange;
   }
-  return props.theme.colors.gray4;
+  return props.theme.colors[color];
 }
 
 function labelColor(props) {
   if (props.error) {
     return props.theme.colors.flameOrange;
+  } else if (props.kind === 'mini') {
+    return props.theme.colors.rocketBlue
   }
   return props.theme.colors.navy;
 }
 
+const regularContainerStyles = css`
+  border: 1px solid ${props => pickColor(props, 'gray4')}
+`
+
+const miniContainerStyles = css`
+  border: 3px solid ${props => pickColor(props, 'lightPink')}
+`
+
+const containerVariants = {
+  regular: regularContainerStyles,
+  mini: miniContainerStyles
+}
+
+const regularSelectStyles = css`
+  color: ${props => props.theme.colors.navy};
+
+  &:focus {
+    color: ${props => props.theme.colors.rocketBlue};
+  }
+`
+
+const miniSelectStyles = css`
+  color: ${props => props.theme.colors.rocketBlue};
+`
+
+const selectVariants = {
+  regular: regularSelectStyles,
+  mini: miniSelectStyles
+}
+
 const Container = styled.div`
   background-color: white;
-  border: 1px solid ${borderColor};
   padding: 10px 16px 0px;
-  color: ${props => props.theme.colors.gray4};
+  ${props => containerVariants[props.kind]};
 `
 
 const Label = styled.label`
@@ -46,6 +77,7 @@ const SelectInput = styled.select`
   font-family: ${props => props.theme.fonts.secondaryFont};
   outline: none;
   background-color: transparent;
+  ${props => selectVariants[props.kind]}
 `
 
 const Select = (props) => {
@@ -53,6 +85,7 @@ const Select = (props) => {
     active,
     className,
     error,
+    kind,
     label,
     name,
     onBlur,
@@ -66,14 +99,15 @@ const Select = (props) => {
   const showError = (touched && !active && error)
   return (
     <div className={className}>
-      <Container active={active} error={showError}>
+      <Container active={active} error={showError} kind={kind}>
         {label &&
-          <Label error={showError}>{label}</Label>
+          <Label error={showError} kind={kind}>{label}</Label>
         }
         <SelectInput
           onChange={onChange}
           onBlur={onBlur}
           onFocus={onFocus}
+          kind={kind}
           name={name}
           value={value}
         >
@@ -95,6 +129,7 @@ Select.propTypes = {
   active: PropTypes.bool,
   className: PropTypes.string,
   error: PropTypes.string,
+  kind: PropTypes.string,
   label: PropTypes.string,
   name: PropTypes.string,
   onBlur: PropTypes.func,
@@ -111,6 +146,7 @@ Select.defaultProps = {
   active: false,
   className: null,
   error: null,
+  kind: 'regular',
   label: null,
   name: null,
   touched: false

--- a/src/components/inputs/Select/Select.md
+++ b/src/components/inputs/Select/Select.md
@@ -44,3 +44,31 @@
   ]}
 />
 ```
+
+## Mini Styles
+
+#### Normal Input
+```js
+<Select
+  kind='mini'
+  label='City'
+  options={[
+    { value: 'NY', text: 'New York' },
+    { value: 'CA', text: 'California' }
+  ]}
+/>
+```
+
+#### Input With Errors
+```js
+<Select
+  error='Some error message'
+  kind='mini'
+  label='City'
+  options={[
+    { value: 'NY', text: 'New York' },
+    { value: 'CA', text: 'California' }
+  ]}
+  touched={true}
+/>
+```


### PR DESCRIPTION
#### What does this PR do?
This PR adds a mini style variant to the regular select component for use in the quiz checkout form and elsewhere.

#### Screenshots
![Screen Shot 2021-11-04 at 12 22 24 PM](https://user-images.githubusercontent.com/38845073/140388617-9d5ebe75-d4ca-4fa3-ab81-0977a54fb48a.png)

#### Relevant Tickets
https://app.shortcut.com/rockets/story/9430/mini-subscription-lead-sees-styling-on-billing-shipping-screen