### PR TITLE
Add color props to more text components

### DIFF
--- a/src/components/curvedText/curvedText.js
+++ b/src/components/curvedText/curvedText.js
@@ -66,7 +66,8 @@ CurvedText.propTypes = {
   objectSize: PropTypes.number,
   spacing: PropTypes.number,
   offset: PropTypes.number,
-  overlap: PropTypes.bool
+  overlap: PropTypes.bool,
+  color: PropTypes.string
 }
 
 CurvedText.defaultProps = {

--- a/src/components/curvedText/curvedText.js
+++ b/src/components/curvedText/curvedText.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
+import colorFromProp from 'utils/colors'
 
 // Sourced from this gist: https://gist.github.com/garth/0ca97a1112cb969cb72d951a85d3a0fe
 /*
@@ -31,7 +32,7 @@ const CurvedText = (props) => {
   const Container = styled.div`
     margin-bottom: ${overlap ? `-${r}px` : '0'};
     height: ${r + offset}px;
-    color: ${props => props.theme.colors.navy};
+    color: ${colorFromProp('color')};
     
     path {
       fill: transparent;
@@ -73,7 +74,8 @@ CurvedText.defaultProps = {
   objectSize: 250,
   spacing: 12,
   offset: 40,
-  overlap: true
+  overlap: true,
+  color: 'navy'
 }
 
 /** @component */

--- a/src/components/inputs/Checkbox/Checkbox.js
+++ b/src/components/inputs/Checkbox/Checkbox.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-
+import colorFromProp from 'utils/colors'
 import CheckboxSVG from './CheckboxSVG.base'
 import Rect from './Rect.base'
 import Check from './Check.base'
@@ -54,6 +54,10 @@ const Checkbox = styled(CheckboxBase)`
     display: none; 
   }
 
+  ${CheckboxSVG} ${Rect} {
+    stroke: ${colorFromProp('borderColor')};
+  }
+
   input {
     width: 0;
     height: 0;
@@ -61,19 +65,22 @@ const Checkbox = styled(CheckboxBase)`
   }
 
   input:checked + ${CheckboxSVG} ${Rect} {
-    fill: ${props => props.theme.colors.rocketBlue};
+    fill: ${colorFromProp('fillColor')};
   }
 
   input:checked + ${CheckboxSVG} ${Check} {
     display: block;
-    stroke: ${props => props.theme.colors.white};
+    stroke: ${colorFromProp('checkColor')};
     stroke-dasharray: 200;
     stroke-dashoffset: 0;
   }
 `
 
 Checkbox.propTypes = {
+  borderColor: PropTypes.string,
+  checkColor: PropTypes.string,
   className: PropTypes.string,
+  fillColor: PropTypes.string,
   input: PropTypes.object.isRequired,
   label: PropTypes.string,
   labelColor: PropTypes.string,
@@ -86,6 +93,9 @@ Checkbox.propTypes = {
 }
 
 Checkbox.defaultProps = {
+  borderColor: 'rocketBlue',
+  checkColor: 'white',
+  fillColor: 'rocketBlue',
   labelColor: 'navy'
 }
 

--- a/src/components/inputs/Checkbox/Checkbox.js
+++ b/src/components/inputs/Checkbox/Checkbox.js
@@ -95,8 +95,7 @@ Checkbox.propTypes = {
 Checkbox.defaultProps = {
   borderColor: 'rocketBlue',
   checkColor: 'white',
-  fillColor: 'rocketBlue',
-  labelColor: 'navy'
+  fillColor: 'rocketBlue'
 }
 
 /** @component */

--- a/src/components/inputs/Checkbox/Checkbox.js
+++ b/src/components/inputs/Checkbox/Checkbox.js
@@ -16,10 +16,10 @@ class CheckboxBase extends React.Component {
   }
 
   render() {
-    const { className, input, children, label, width, ...props } = this.props
+    const { className, input, children, label, labelColor, width, ...props } = this.props
 
     return (
-      <Label {...props} lowercase className={className}>
+      <Label {...props} color={labelColor} lowercase className={className}>
         <input
           type='checkbox'
           onClick={this.onClick}
@@ -50,6 +50,10 @@ const Checkbox = styled(CheckboxBase)`
     flex-shrink: 0;
   }
 
+  ${CheckboxSVG} ${Check} {
+    display: none; 
+  }
+
   input {
     width: 0;
     height: 0;
@@ -61,6 +65,7 @@ const Checkbox = styled(CheckboxBase)`
   }
 
   input:checked + ${CheckboxSVG} ${Check} {
+    display: block;
     stroke: ${props => props.theme.colors.white};
     stroke-dasharray: 200;
     stroke-dashoffset: 0;
@@ -71,12 +76,17 @@ Checkbox.propTypes = {
   className: PropTypes.string,
   input: PropTypes.object.isRequired,
   label: PropTypes.string,
+  labelColor: PropTypes.string,
   theme: PropTypes.shape({
     colors: PropTypes.shape({
       rocketBlue: PropTypes.string,
       white: PropTypes.string
     })
   })
+}
+
+Checkbox.defaultProps = {
+  labelColor: 'navy'
 }
 
 /** @component */

--- a/src/components/inputs/Checkbox/Checkbox.md
+++ b/src/components/inputs/Checkbox/Checkbox.md
@@ -28,3 +28,29 @@
     Resized Example Checkbox
   </Checkbox>
 ```
+
+### Checkbox with different label color
+```js
+<Checkbox
+  labelColor='rocketBlue'
+  width='1.5rem'
+  input={{
+    checked: true
+  }}>
+    Rocket blue checkbox label
+</Checkbox>
+```
+
+### Checkbox with different checkbox colors
+```js
+<Checkbox
+  borderColor='red'
+  checkColor='red'
+  fillColor='yellow'
+  labelColor='rocketBlue'
+  width='5rem'
+  >
+  Rocket blue checkbox label
+</Checkbox>
+```
+

--- a/src/components/inputs/Checkbox/Rect.base.js
+++ b/src/components/inputs/Checkbox/Rect.base.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 const Rect = ({ className }) => {
@@ -10,19 +9,9 @@ const Rect = ({ className }) => {
 
 const StyledRect = styled(Rect)`
   fill: none;
-
-  stroke: ${props => props.theme.colors.rocketBlue};
   stroke-width: 20;
   stroke-linecap: round;
 `
-
-StyledRect.propTypes = {
-  theme: PropTypes.shape({
-    colors: PropTypes.shape({
-      rocketBlue: PropTypes.string
-    })
-  })
-}
 
 export default StyledRect
 export { Rect }

--- a/src/core/typography/H1.js
+++ b/src/core/typography/H1.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-
 import colorFromProp from 'utils/colors'
 
 const H1 = styled.h1`

--- a/src/core/typography/H2.js
+++ b/src/core/typography/H2.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import colorFromProp from 'utils/colors'
 
 const H2 = styled.h2`
     ${props => props.center ? 'text-align: center;' : ''}
@@ -7,7 +8,7 @@ const H2 = styled.h2`
     text-transform: ${props => props.lowercase
       ? 'inherit' : 'uppercase'};
 
-    color: ${props => props.theme.colors.navy};
+    color: ${colorFromProp('color')};
 
     font-family: ${props => props.theme.fonts.headerFont};
     font-size: ${props => props.fontSizes.mobile};
@@ -37,7 +38,8 @@ H2.defaultProps = {
     desktop: '3.2rem',
     mobile: '2.4rem'
   },
-  margin: '2.6rem 0'
+  margin: '2.6rem 0',
+  color: 'navy'
 }
 
 export default H2

--- a/src/core/typography/H2.js
+++ b/src/core/typography/H2.js
@@ -6,10 +6,10 @@ const H2 = styled.h2`
     ${props => props.center ? 'text-align: center;' : ''}
     letter-spacing: .05rem;
     text-transform: ${props => props.lowercase
-      ? 'inherit' : 'uppercase'};
-
+      ? 'inherit'
+      : 'uppercase'
+    };
     color: ${colorFromProp('color')};
-
     font-family: ${props => props.theme.fonts.headerFont};
     font-size: ${props => props.fontSizes.mobile};
     ${props => props.theme.breakpointsVerbose.aboveTablet`
@@ -25,9 +25,6 @@ H2.propTypes = {
   theme: PropTypes.shape({
     fonts: PropTypes.shape({
       headerFont: PropTypes.string
-    }),
-    colors: PropTypes.shape({
-      navy: PropTypes.string
     })
   }),
   lowercase: PropTypes.bool

--- a/src/core/typography/Label.js
+++ b/src/core/typography/Label.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
+import colorFromProp from 'utils/colors'
 
 const styles = css`
   text-align: ${props => props.alignRight ? 'right' : 'left'};
@@ -18,7 +19,7 @@ const styles = css`
 const Label = styled.label`
   ${styles}
 
-  color: ${props => props.theme.colors.navy}
+  color: ${colorFromProp('color')};
 `
 
 const LowercaseLabel = ({className, children}) => {
@@ -44,10 +45,12 @@ Label.propTypes = {
       navy: PropTypes.string
     })
   }),
-  lowercase: PropTypes.bool
+  lowercase: PropTypes.bool,
+  color: PropTypes.string
 }
 
 Label.defaultProps = {
+  color: 'navy',
   letterSpacing: '.1rem',
   fontSize: '1.4rem',
   fontWeight: '500'

--- a/src/core/typography/Label.js
+++ b/src/core/typography/Label.js
@@ -8,9 +8,9 @@ const styles = css`
   margin-bottom: 0;
   letter-spacing: ${props => props.letterSpacing};
   text-transform: ${props => props.lowercase
-    ? 'inherit' : 'uppercase'};
-
-
+    ? 'inherit'
+    : 'uppercase'
+  };
   font-family: ${props => props.theme.fonts.primaryFont};
   font-size: ${props => props.fontSize};
   font-weight: ${props => props.fontWeight};
@@ -18,19 +18,19 @@ const styles = css`
 
 const Label = styled.label`
   ${styles}
-
   color: ${colorFromProp('color')};
 `
 
-const LowercaseLabel = ({className, children}) => {
+const LowercaseLabel = ({ className, children }) => {
   return (
     <Label
       className={className}
       fontSize='2rem'
       letterSpacing='normal'
       fontWeight='normal'
-      lowercase>
-        {children}
+      lowercase
+    >
+      {children}
     </Label>
   )
 }
@@ -40,9 +40,6 @@ Label.propTypes = {
   theme: PropTypes.shape({
     fonts: PropTypes.shape({
       primaryFont: PropTypes.string
-    }),
-    colors: PropTypes.shape({
-      navy: PropTypes.string
     })
   }),
   lowercase: PropTypes.bool,

--- a/src/core/typography/Label.md
+++ b/src/core/typography/Label.md
@@ -7,3 +7,13 @@
 ```js
 <Label lowercase>{'I\'m a thing.'}</Label>
 ```
+
+### Label with different colors:
+
+```js
+<Label color='rocketBlue'>{'I\'m blue da-ba-dee-da-ba-da.'}</Label>
+```
+
+```js
+<Label color='flameOrange'>{'I\'m orange da-ba-dee-da-ba-da.'}</Label>
+```


### PR DESCRIPTION
#### What does this PR do?
This PR adds a color prop to H2, Label, CurvedText, and ensures that we can control the colors for checkboxes and their associated labels. These changes are needed to support the different stylings we're trying to implement in mini. 

#### Relevant Tickets
https://app.shortcut.com/rockets/story/9430/mini-subscription-lead-sees-styling-on-billing-shipping-screen