### PR TITLE
Prevent customers from removing multiple items at the same time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.509",
+  "version": "0.1.510",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.509",
+  "version": "0.1.510",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/components/inputs/ErrorMessage/ErrorMessage.js
+++ b/src/components/inputs/ErrorMessage/ErrorMessage.js
@@ -16,4 +16,5 @@ const ErrorMessage = styled.div`
   line-height: 18px;
 `
 
+/** @component */
 export default ErrorMessage

--- a/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.js
+++ b/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import accounting from 'accounting'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { XIcon, GraySpinner } from 'SRC'
 
 import cloudinary from 'services/cloudinary'
@@ -98,14 +98,24 @@ const Attribute = styled.div`
   }
 `
 
-const Remove = styled(XIcon)`
-  height: 12px;
+const RemoveContainer = styled.div`
   margin-left: 10px;
   margin-right: 20px;
   margin-top: 5px;
-  width: 12px;
+  min-width: 21px;
+  text-align: center;
+`
 
+const Remove = styled(XIcon)`
+  height: 12px;
+  width: 12px;
   cursor: pointer;
+  transition: opacity 200ms;
+
+  ${props => props.disabled && css`
+    opacity: 0.5;
+    pointer-events: none;
+  `}
 `
 
 const AttributeContainer = styled.div`
@@ -152,7 +162,6 @@ class BaseProduct extends React.Component {
 
   onRemoveItem = () => {
     const { item, segmentProductRemoved, onRemoveItem } = this.props
-
     onRemoveItem(item.id)
     segmentProductRemoved(item, 'bag')
   }
@@ -205,6 +214,15 @@ class BaseProduct extends React.Component {
         }
       </Select>
     )
+  }
+
+  renderRemoveIcon = () => {
+    const { removingItemId, item } = this.props
+
+    if (removingItemId === item.id) {
+      return <GraySpinner size="21px" />
+    }
+    return <Remove onClick={this.onRemoveItem} disabled={!!removingItemId} />
   }
 
   showRemoveItem = () => {
@@ -276,7 +294,9 @@ class BaseProduct extends React.Component {
           }
           {item.on_sale && finalSaleOn && <ItemName>FINAL SALE</ItemName>}
         </AttributeContainer>
-        {this.showRemoveItem() && <Remove onClick={this.onRemoveItem} />}
+        <RemoveContainer>
+          {this.renderRemoveIcon()}
+        </RemoveContainer>
       </div>
     )
   }
@@ -301,6 +321,7 @@ BaseProduct.propTypes = {
   onRemoveItem: PropTypes.func.isRequired,
   onUpdateQuantity: PropTypes.func.isRequired,
   onUpdateSize: PropTypes.func.isRequired,
+  removingItemId: PropTypes.number,
   renderLink: PropTypes.func,
   segmentProductRemoved: PropTypes.func
 }
@@ -313,7 +334,9 @@ const renderLink = (inProps) => {
 BaseProduct.defaultProps = {
   isUpdatingQuantity: false,
   isUpdatingSize: false,
+  removingItemId: null,
   renderLink: renderLink
 }
 
+/** @component */
 export default Product

--- a/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.md
+++ b/src/modules/persistent-cart/persistentCartProduct/persistentCartProduct.md
@@ -1,3 +1,4 @@
+#### Default state
 ```js
 <PersistentCartProduct
   item={{
@@ -107,6 +108,239 @@
   onUpdateQuantity={(item, quantity) => console.log('Update Quantity', item, quantity)}
   onUpdateSize={(item, size) => console.log('Update Size', item, size)}
   onRemoveItem={(itemId) => console.log('Remove item', itemId)}
+  segmentProductRemoved={() => null}
+  hideCartSidebar={() => {}}
+/>
+```
+
+#### Removing this line item state
+```js
+<PersistentCartProduct
+  item={{
+    id: 2943132,
+    price: "34.5",
+    amount: "34.5",
+    total: "34.5",
+    variant_id: 19915,
+    sku: "7084-025-N",
+    quantity: 1,
+    name: "Varsity Sequin Skirt",
+    color: "Silver",
+    size: "10",
+    category: [
+      "Bottoms",
+      "Skirts"
+    ],
+    cost_price: null,
+    product_id: 894,
+    slug: "sequin-skirt-7084",
+    colorway_slug: "silver",
+    colorway_code: "7084-025",
+    order_id: 772492,
+    on_sale: false,
+    original_price: "34.5",
+    colorway_variants: [
+      {
+        id: 11566,
+        sku: "7084-025-C",
+        size: "4/5",
+        in_stock: false
+      },
+      {
+        id: 11562,
+        sku: "7084-025-H",
+        size: "3",
+        in_stock: false
+      },
+      {
+        id: 16484,
+        sku: "7084-025-I",
+        size: "4",
+        in_stock: false
+      },
+      {
+        id: 16486,
+        sku: "7084-025-K",
+        size: "5",
+        in_stock: false
+      },
+      {
+        id: 11567,
+        sku: "7084-025-D",
+        size: "6/7",
+        in_stock: false
+      },
+      {
+        id: 16485,
+        sku: "7084-025-L",
+        size: "6",
+        in_stock: false
+      },
+      {
+        id: 16483,
+        sku: "7084-025-M",
+        size: "7",
+        in_stock: false
+      },
+      {
+        id: 11563,
+        sku: "7084-025-E",
+        size: "8",
+        in_stock: false
+      },
+      {
+        id: 11565,
+        sku: "7084-025-F",
+        size: "10/12",
+        in_stock: false
+      },
+      {
+        id: 19915,
+        sku: "7084-025-N",
+        size: "10",
+        in_stock: true
+      },
+      {
+        id: 19914,
+        sku: "7084-025-O",
+        size: "12",
+        in_stock: true
+      },
+      {
+        id: 11564,
+        sku: "7084-025-P",
+        size: "14",
+        in_stock: false
+      }
+    ],
+    shot: {
+      id: 4503793,
+      shot_type: "front",
+      cloudinary_key: "production/catalog/kirtmym9iy3c5wirjihg"
+    },
+    adjustments: []
+  }}
+  onUpdateQuantity={(item, quantity) => console.log('Update Quantity', item, quantity)}
+  onUpdateSize={(item, size) => console.log('Update Size', item, size)}
+  onRemoveItem={(itemId) => console.log('Remove item', itemId)}
+  removingItemId={2943132}
+  segmentProductRemoved={() => null}
+  hideCartSidebar={() => {}}
+/>
+```
+
+#### Removing another line item state
+```js
+<PersistentCartProduct
+  item={{
+    id: 2943132,
+    price: "34.5",
+    amount: "34.5",
+    total: "34.5",
+    variant_id: 19915,
+    sku: "7084-025-N",
+    quantity: 1,
+    name: "Varsity Sequin Skirt",
+    color: "Silver",
+    size: "10",
+    category: [
+      "Bottoms",
+      "Skirts"
+    ],
+    cost_price: null,
+    product_id: 894,
+    slug: "sequin-skirt-7084",
+    colorway_slug: "silver",
+    colorway_code: "7084-025",
+    order_id: 772492,
+    on_sale: false,
+    original_price: "34.5",
+    colorway_variants: [
+      {
+        id: 11566,
+        sku: "7084-025-C",
+        size: "4/5",
+        in_stock: false
+      },
+      {
+        id: 11562,
+        sku: "7084-025-H",
+        size: "3",
+        in_stock: false
+      },
+      {
+        id: 16484,
+        sku: "7084-025-I",
+        size: "4",
+        in_stock: false
+      },
+      {
+        id: 16486,
+        sku: "7084-025-K",
+        size: "5",
+        in_stock: false
+      },
+      {
+        id: 11567,
+        sku: "7084-025-D",
+        size: "6/7",
+        in_stock: false
+      },
+      {
+        id: 16485,
+        sku: "7084-025-L",
+        size: "6",
+        in_stock: false
+      },
+      {
+        id: 16483,
+        sku: "7084-025-M",
+        size: "7",
+        in_stock: false
+      },
+      {
+        id: 11563,
+        sku: "7084-025-E",
+        size: "8",
+        in_stock: false
+      },
+      {
+        id: 11565,
+        sku: "7084-025-F",
+        size: "10/12",
+        in_stock: false
+      },
+      {
+        id: 19915,
+        sku: "7084-025-N",
+        size: "10",
+        in_stock: true
+      },
+      {
+        id: 19914,
+        sku: "7084-025-O",
+        size: "12",
+        in_stock: true
+      },
+      {
+        id: 11564,
+        sku: "7084-025-P",
+        size: "14",
+        in_stock: false
+      }
+    ],
+    shot: {
+      id: 4503793,
+      shot_type: "front",
+      cloudinary_key: "production/catalog/kirtmym9iy3c5wirjihg"
+    },
+    adjustments: []
+  }}
+  onUpdateQuantity={(item, quantity) => console.log('Update Quantity', item, quantity)}
+  onUpdateSize={(item, size) => console.log('Update Size', item, size)}
+  onRemoveItem={(itemId) => console.log('Remove item', itemId)}
+  removingItemId={1234}
+  segmentProductRemoved={() => null}
   hideCartSidebar={() => {}}
 />
 ```

--- a/src/modules/persistent-cart/persistentCartProductList/persistentCartProductList.js
+++ b/src/modules/persistent-cart/persistentCartProductList/persistentCartProductList.js
@@ -16,6 +16,21 @@ const BagListWrapper = styled.div`
 `
 
 class BasePersistentCartProductList extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { removingItemId: null }
+
+    this.handleRemoveItem = this.handleRemoveItem.bind(this)
+  }
+
+  async handleRemoveItem (id) {
+    const { removeItem } = this.props
+
+    this.setState({ removingItemId: id })
+    await removeItem(id)
+    this.setState({ removingItemId: null })
+  }
+
   componentDidMount () {
     const { lineItems, segmentCartViewed } = this.props
     if (lineItems) {
@@ -36,7 +51,6 @@ class BasePersistentCartProductList extends Component {
       lineItems,
       onUpdateQuantity,
       onUpdateSize,
-      removeItem,
       hideCartSidebar,
       renderProductLink,
       segmentProductRemoved,
@@ -44,6 +58,7 @@ class BasePersistentCartProductList extends Component {
       isUpdatingQuantity,
       isUpdatingSize
     } = this.props
+    const { removingItemId } = this.state
 
     return (
       <section className={className}>
@@ -55,13 +70,14 @@ class BasePersistentCartProductList extends Component {
                 item={lineItem}
                 onUpdateQuantity={onUpdateQuantity}
                 onUpdateSize={onUpdateSize}
-                onRemoveItem={removeItem}
+                onRemoveItem={this.handleRemoveItem}
                 renderLink={renderProductLink}
                 segmentProductRemoved={segmentProductRemoved}
                 hideCartSidebar={hideCartSidebar}
                 finalSaleOn={finalSaleOn}
                 isUpdatingSize={isUpdatingSize === lineItem.id}
                 isUpdatingQuantity={isUpdatingQuantity === lineItem.id}
+                removingItemId={removingItemId}
               />
             )}
           </BagListWrapper>

--- a/src/modules/persistent-cart/persistentCartProductList/persistentCartProductList.md
+++ b/src/modules/persistent-cart/persistentCartProductList/persistentCartProductList.md
@@ -2,7 +2,111 @@
 <PersistentCartProductList
   lineItems={[
     {
-      id: 2943132,
+      id: 1,
+      price: "34.5",
+      amount: "34.5",
+      total: "34.5",
+      variant_id: 19915,
+      sku: "7084-025-N",
+      quantity: 1,
+      name: "Varsity Sequin Skirt",
+      color: "Silver",
+      size: "10",
+      category: [
+        "Bottoms",
+        "Skirts"
+      ],
+      cost_price: null,
+      product_id: 894,
+      slug: "sequin-skirt-7084",
+      colorway_slug: "silver",
+      colorway_code: "7084-025",
+      order_id: 772492,
+      on_sale: false,
+      original_price: "34.5",
+      colorway_variants: [
+        {
+          id: 11562,
+          sku: "7084-025-H",
+          size: "3",
+          in_stock: false
+        },
+        {
+          id: 11566,
+          sku: "7084-025-C",
+          size: "4/5",
+          in_stock: false
+        },
+        {
+          id: 16484,
+          sku: "7084-025-I",
+          size: "4",
+          in_stock: false
+        },
+        {
+          id: 16486,
+          sku: "7084-025-K",
+          size: "5",
+          in_stock: false
+        },
+        {
+          id: 11567,
+          sku: "7084-025-D",
+          size: "6/7",
+          in_stock: false
+        },
+        {
+          id: 16485,
+          sku: "7084-025-L",
+          size: "6",
+          in_stock: false
+        },
+        {
+          id: 16483,
+          sku: "7084-025-M",
+          size: "7",
+          in_stock: false
+        },
+        {
+          id: 11563,
+          sku: "7084-025-E",
+          size: "8",
+          in_stock: false
+        },
+        {
+          id: 11565,
+          sku: "7084-025-F",
+          size: "10/12",
+          in_stock: false
+        },
+        {
+          id: 19915,
+          sku: "7084-025-N",
+          size: "10",
+          in_stock: true
+        },
+        {
+          id: 19914,
+          sku: "7084-025-O",
+          size: "12",
+          in_stock: true
+        },
+        {
+          id: 11564,
+          sku: "7084-025-P",
+          size: "14",
+          in_stock: false
+        }
+      ],
+      shot: {
+        id: 4503793,
+        shot_type: "front",
+        cloudinary_key: "production/catalog/kirtmym9iy3c5wirjihg"
+      },
+      adjustments: []
+    },
+    {
+      id: 2,
       price: "34.5",
       amount: "34.5",
       total: "34.5",
@@ -108,9 +212,13 @@
   ]}
   onUpdateQuantity={(item, quantity) => console.log('Update quantity', item, quantity)}
   onUpdateSize={(item, size) => console.log('Update size', item, size)}
-  removeItem={() => console.log('Remove item')}
-  hideCartSidebar={() => {}}
-  segmentCartViewed={() => {}}
+  removeItem={(id) => {
+    console.log('Removing item', id)
+    return new Promise((resolve) => setTimeout(resolve, 1000))
+  }}
+  hideCartSidebar={() => null}
+  segmentCartViewed={() => null}
+  segmentProductRemoved={() => null}
   isUpdatingSize={2943132}
 />
 ```


### PR DESCRIPTION
#### What does this PR do?
With this change we'll prevent customers from removing multiple line items from their cart simultaneously, as this causes a race condition on the backend which could potentially create orphaned adjustments, which prevent the customer from checking out.

#### Screenshots
![Demo](http://recordit.co/7Ud7RYY4BT.gif)

#### Relevant Tickets
https://app.shortcut.com/rockets/story/9448/customers-are-not-able-to-checkout-due-to-orphaned-adjustments
