### PR TITLE
Add wrap and column gap props to flexRow component

### DIFF
--- a/src/core/grid/flexRow.js
+++ b/src/core/grid/flexRow.js
@@ -29,8 +29,9 @@ const FlexRow = styled(BaseFlexRow)`
   box-sizing: border-box;
   flex-basis: 100%;
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: ${props => props.wrap};
   justify-content: ${props => props.align};
+  column-gap: ${props => props.columnGap}
   ${props => props.constrained ? constrained : notConstrained}
   ${props => props.padding && padding}
 `
@@ -42,12 +43,15 @@ FlexRow.propTypes = {
   ]),
   constrained: PropTypes.bool,
   padding: PropTypes.bool,
-  align: PropTypes.string
+  align: PropTypes.string,
+  columnGap: PropTypes.string,
+  wrap: PropTypes.bool
 }
 
 FlexRow.defaultProps = {
   element: 'div',
-  align: 'flex-start'
+  align: 'flex-start',
+  wrap: true
 }
 /** @component */
 export default FlexRow

--- a/src/core/grid/flexRow.js
+++ b/src/core/grid/flexRow.js
@@ -45,13 +45,13 @@ FlexRow.propTypes = {
   padding: PropTypes.bool,
   align: PropTypes.string,
   columnGap: PropTypes.string,
-  wrap: PropTypes.bool
+  wrap: PropTypes.string
 }
 
 FlexRow.defaultProps = {
   element: 'div',
   align: 'flex-start',
-  wrap: true
+  wrap: 'wrap'
 }
 /** @component */
 export default FlexRow


### PR DESCRIPTION
#### What does this PR do?
This PR adds `wrap` and `columnGap` props to the `flexRow` component to allow for more explicit styling of children `flexCols`.
