### PR TITLE
Add explicit negative margin prop on curvedText and verticalAlign on …

### DIFF
--- a/src/components/curvedText/curvedText.js
+++ b/src/components/curvedText/curvedText.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import colorFromProp from 'utils/colors'
 
 const Container = styled.div`
-  margin-bottom: ${props => props.overlap ? '-100px' : '0'};
+  margin-bottom: ${props => props.marginBottom};
   margin-left: auto;
   margin-right: auto;
   max-height: 200px;
@@ -53,14 +53,16 @@ CurvedText.propTypes = {
   letterSpacing: PropTypes.string,
   text: PropTypes.string.isRequired,
   overlap: PropTypes.bool,
-  color: PropTypes.string
+  color: PropTypes.string,
+  marginBottom: PropTypes.string
 }
 
 CurvedText.defaultProps = {
   fontSize: '1.6rem',
   letterSpacing: 'normal',
   overlap: true,
-  color: 'textPrimary'
+  color: 'textPrimary',
+  marginBottom: '100px'
 }
 
 /** @component */

--- a/src/components/curvedText/curvedText.js
+++ b/src/components/curvedText/curvedText.js
@@ -52,7 +52,6 @@ CurvedText.propTypes = {
   fontSize: PropTypes.string,
   letterSpacing: PropTypes.string,
   text: PropTypes.string.isRequired,
-  overlap: PropTypes.bool,
   color: PropTypes.string,
   marginBottom: PropTypes.string
 }
@@ -60,7 +59,6 @@ CurvedText.propTypes = {
 CurvedText.defaultProps = {
   fontSize: '1.6rem',
   letterSpacing: 'normal',
-  overlap: true,
   color: 'textPrimary',
   marginBottom: '100px'
 }

--- a/src/components/curvedText/curvedText.js
+++ b/src/components/curvedText/curvedText.js
@@ -60,7 +60,7 @@ CurvedText.defaultProps = {
   fontSize: '1.6rem',
   letterSpacing: 'normal',
   color: 'textPrimary',
-  marginBottom: '100px'
+  marginBottom: '-100px'
 }
 
 /** @component */

--- a/src/core/grid/flexRow.js
+++ b/src/core/grid/flexRow.js
@@ -30,6 +30,7 @@ const FlexRow = styled(BaseFlexRow)`
   flex-basis: 100%;
   display: flex;
   justify-content: ${props => props.align};
+  align-items: ${props => props.verticalAlign};
   flex-wrap: ${props => props.mobile.wrap};
   column-gap: ${props => props.mobile.columnGap};
   ${props => props.constrained ? constrained : notConstrained};
@@ -52,6 +53,7 @@ FlexRow.propTypes = {
   constrained: PropTypes.bool,
   padding: PropTypes.bool,
   align: PropTypes.string,
+  verticalAlign: PropTypes.string,
   mobile: PropTypes.shape({
     columnGap: PropTypes.string,
     wrap: PropTypes.string


### PR DESCRIPTION
…flexRow

#### What does this PR do?
This PR adds a `marginBottom` prop on the CurvedText component to allow for more fine tuning of its position relative to other content on the page and a `verticalAlign` prop to the FlexRow component to set its `align-items` style.

#### Screenshots


#### Notes


#### PR Dependencies


#### Relevant Tickets
