### PR TITLE
Use relative paths for navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.517",
+  "version": "0.1.518",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsofawesome/mirage",
-  "version": "0.1.517",
+  "version": "0.1.518",
   "main": "./build/index.js",
   "dependencies": {
     "accounting": "^0.4.1",

--- a/src/modules/header/desktopNavigation/desktopNavigation.js
+++ b/src/modules/header/desktopNavigation/desktopNavigation.js
@@ -70,7 +70,6 @@ export class BaseDesktopNavigation extends React.Component {
       boysLinks,
       babyLinks,
       bagCount,
-      homepageUrl,
       clickBag,
       clickSearch,
       showBlog,
@@ -99,10 +98,11 @@ export class BaseDesktopNavigation extends React.Component {
                   <HeaderLink
                     onMouseEnter={this.closeDrawers}
                     onFocus={this.closeDrawers}
-                    href={homepageUrl}
+                    href='/'
                     highlightable={false}
                     renderLink={renderLink}
-                    spacing={false}>
+                    spacing={false}
+                  >
                     <span className='screenReader'>Home</span>
                     <Logo />
                   </HeaderLink>
@@ -157,8 +157,9 @@ export class BaseDesktopNavigation extends React.Component {
                   <HeaderLink
                     onMouseEnter={this.closeDrawers}
                     onFocus={this.closeDrawers}
-                    href={`${homepageUrl}/outfits`}
-                    highlightable={highlightable}>
+                    href='/outfits'
+                    highlightable={highlightable}
+                  >
                       Outfits
                   </HeaderLink>
                 </li>
@@ -167,8 +168,9 @@ export class BaseDesktopNavigation extends React.Component {
                     <HeaderLink
                       onMouseEnter={this.closeDrawers}
                       onFocus={this.closeDrawers}
-                      href={`${homepageUrl}/subscribe-and-save`}
-                      highlightable={highlightable}>
+                      href='/subscribe-and-save'
+                      highlightable={highlightable}
+                    >
                         Subscribe + Save
                     </HeaderLink>
                   </li>
@@ -349,7 +351,6 @@ BaseDesktopNavigation.propTypes = {
   girlsLinks: PropTypes.object,
   boysLinks: PropTypes.object,
   bagCount: PropTypes.number,
-  homepageUrl: PropTypes.string,
   clickBag: PropTypes.func,
   clickSearch: PropTypes.func
 }
@@ -362,7 +363,6 @@ BaseDesktopNavigation.defaultProps = {
   girlsLinks: girls,
   boysLinks: boys,
   babyLinks: baby,
-  homepageUrl: 'https://rocketsofawesome.com',
   showBlog: REACT_APP_SHOW_BLOG_LINK,
   showSearch: false
 }

--- a/src/modules/header/mobileNavigation/mobileNavigation.js
+++ b/src/modules/header/mobileNavigation/mobileNavigation.js
@@ -43,7 +43,6 @@ export class BaseMobileNavigation extends React.Component {
       className,
       drawerPosition,
       loggedIn,
-      homepageUrl,
       renderLink,
       isSubscriptionMember,
       bagCount,
@@ -62,8 +61,9 @@ export class BaseMobileNavigation extends React.Component {
           <BlueHamburger onClick={this.openDrawer} />
           <MobileLinkTop
             className='link-home'
-            href={homepageUrl}
-            renderLink={renderLink}>
+            href='/'
+            renderLink={renderLink}
+          >
             <span className='screenReader'>Home</span>
             <Logo />
           </MobileLinkTop>
@@ -89,12 +89,14 @@ export class BaseMobileNavigation extends React.Component {
             <li>
               <MobileLinkTop
                 target='/shop'
-                renderLink={renderLink}>
+                renderLink={renderLink}
+              >
                 Shop
               </MobileLinkTop>
               <UL
                 leftPad='1rem'
-                type='none'>
+                type='none'
+              >
                 <li>
                   <Accordion
                     toggleElement={
@@ -102,7 +104,8 @@ export class BaseMobileNavigation extends React.Component {
                     }>
                     <UL
                       type='none'
-                      leftPad='1rem'>
+                      leftPad='1rem'
+                    >
                       {boysLinks && boysLinks.map((link, index) => {
                         return (
                           <li key={index}>
@@ -126,7 +129,8 @@ export class BaseMobileNavigation extends React.Component {
                         <li key={index}>
                           <MobileLinkTertiary
                             target={link.target}
-                            renderLink={renderLink}>
+                            renderLink={renderLink}
+                          >
                             {link.text}
                           </MobileLinkTertiary>
                         </li>
@@ -141,39 +145,38 @@ export class BaseMobileNavigation extends React.Component {
                       <MobileLinkSecondary>Baby</MobileLinkSecondary>
                     }>
                     <UL type='none' leftPad='1rem'>
-                    {babyLinks && babyLinks.map((link, index) => {
-                      return (
-                        <li key={index}>
-                          <MobileLinkTertiary
-                            target={link.target}
-                            renderLink={renderLink}>
-                            {link.text}
-                          </MobileLinkTertiary>
-                        </li>
-                      )
-                    })}
+                      {
+                        babyLinks && babyLinks.map((link, index) => {
+                          return (
+                            <li key={index}>
+                              <MobileLinkTertiary
+                                target={link.target}
+                                renderLink={renderLink}>
+                                {link.text}
+                              </MobileLinkTertiary>
+                            </li>
+                          )
+                        })
+                      }
                     </UL>
                   </Accordion>
                 </li>
               </UL>
             </li>
             <li>
-              <MobileLinkTop
-                href={`${homepageUrl}/outfits`}>
+              <MobileLinkTop href='/outfits'>
                 Outfits
               </MobileLinkTop>
             </li>
             {!isSubscriptionMember &&
               <div>
                 <li>
-                  <MobileLinkTop
-                    href={`${homepageUrl}/shop/sale`}>
+                  <MobileLinkTop href='/shop/sale'>
                     Sale
                   </MobileLinkTop>
                 </li>
                 <li>
-                  <MobileLinkTop
-                    href={`${homepageUrl}/subscribe-and-save`}>
+                  <MobileLinkTop href='/subscribe-and-save'>
                     Subscribe + Save
                   </MobileLinkTop>
                 </li>
@@ -182,15 +185,15 @@ export class BaseMobileNavigation extends React.Component {
             {isSubscriptionMember &&
               <div>
                 <li>
-                  <MobileLinkTop
-                    href={`${homepageUrl}/shop/sale`}>
+                  <MobileLinkTop href='/shop/sale'>
                     Sale
                   </MobileLinkTop>
                 </li>
                 <li>
                   <MobileLinkTop
                     target='/box'
-                    renderLink={renderLink}>
+                    renderLink={renderLink}
+                  >
                     Box
                   </MobileLinkTop>
                 </li>
@@ -198,28 +201,32 @@ export class BaseMobileNavigation extends React.Component {
                   <MobileLinkTop
                     target='/invite'
                     renderLink={renderLink}
-                    background={theme.colors.lightPink}>
+                    background={theme.colors.lightPink}
+                  >
                     Refer a Friend
                   </MobileLinkTop>
                 </li>
                 <li>
                   <MobileLinkTop
                     target='/reverse'
-                    renderLink={renderLink}>
+                    renderLink={renderLink}
+                  >
                     Rockets Reverse
                   </MobileLinkTop>
                 </li>
                 <li>
                   <MobileLinkTop
                     target='/style-file'
-                    renderLink={renderLink}>
+                    renderLink={renderLink}
+                  >
                     Style File
                   </MobileLinkTop>
                 </li>
                 <li>
                   <MobileLinkTop
                     target='/orders'
-                    renderLink={renderLink}>
+                    renderLink={renderLink}
+                  >
                     Order History
                   </MobileLinkTop>
                 </li>
@@ -229,7 +236,8 @@ export class BaseMobileNavigation extends React.Component {
               <li>
                 <MobileLinkTop
                   target='/shop/login'
-                  renderLink={renderLink}>
+                  renderLink={renderLink}
+                >
                   Login
                 </MobileLinkTop>
               </li>
@@ -245,7 +253,8 @@ export class BaseMobileNavigation extends React.Component {
               <MobileAccountLinks
                 isSubscriptionMember={isSubscriptionMember}
                 renderLink={renderLink}
-                signOut={signOut} />
+                signOut={signOut}
+              />
             }
           </UL>
         </MenuDrawer>
@@ -288,7 +297,6 @@ const MobileNavigation = styled(BaseMobileNavigation)`
 MobileNavigation.propTypes = {
   drawerPosition: PropTypes.string,
   bagCount: PropTypes.number,
-  homepageUrl: PropTypes.string,
   boysLinks: PropTypes.array,
   girlsLinks: PropTypes.array,
   className: PropTypes.string,
@@ -301,7 +309,6 @@ MobileNavigation.propTypes = {
 
 MobileNavigation.defaultProps = {
   drawerPosition: 'fixed',
-  homepageUrl: 'https://rocketsofawesome.com',
   showBlog: REACT_APP_SHOW_BLOG_LINK,
   showSearch: false
 }

--- a/src/utils/shotSorter.js
+++ b/src/utils/shotSorter.js
@@ -11,7 +11,7 @@ export const shotTypeSortOrder = [
   'other'
 ]
 
-function sortShots(shots) {
+export function sortShots(shots) {
   return shots.sort((shot1, shot2) =>
     shotTypeSortOrder.indexOf(shot1.shot_type) - shotTypeSortOrder.indexOf(shot2.shot_type)
   )


### PR DESCRIPTION
#### What does this PR do?
With this change we'll update the desktop and mobile navigation components so they use relative paths instead of absolute paths, this makes links protocol agnostic which should make them more flexible.

We'll also export the sortShots function as it is used in a ton of different places (PLP, PDP, product tiles, etc.) being able
to import this function will help reduce duplication.
