### PR TITLE
Hide links supporting mini starter kits from nav

### DIFF
--- a/src/modules/header/desktopNavigation/defaultProps.js
+++ b/src/modules/header/desktopNavigation/defaultProps.js
@@ -71,29 +71,6 @@ export const boys = {
   }
 }
 
-export const baby = {
-  regions: {
-    left: [
-      {
-        id: 'category',
-        title: 'Shop by Category',
-        links: [
-          { target: '#', text: 'Shop All' }
-        ]
-      }
-    ],
-    right: [
-      {
-        id: 'story',
-        title: 'Shop by Story',
-        links: [
-          { target: '#', text: 'Starter Kits' }
-        ]
-      }
-    ]
-  }
-}
-
 export const accountLinks = {
   loggedOut: {
     text: 'Login',

--- a/src/modules/header/desktopNavigation/desktopNavigation.js
+++ b/src/modules/header/desktopNavigation/desktopNavigation.js
@@ -11,7 +11,7 @@ import {
   Logo,
   MegaMenu
 } from 'SRC'
-import { girls, boys, baby, renderLink } from './defaultProps'
+import { girls, boys, renderLink } from './defaultProps'
 
 const { REACT_APP_SHOW_BLOG_LINK } = process.env
 
@@ -24,9 +24,6 @@ export class BaseDesktopNavigation extends React.Component {
       },
       girls: {
         visible: false
-      },
-      baby: {
-        visible: false
       }
     }
     this.header = undefined
@@ -35,8 +32,7 @@ export class BaseDesktopNavigation extends React.Component {
   closeDrawers = () => {
     this.setState({
       boys: { visible: false },
-      girls: { visible: false },
-      baby: { visible: false }
+      girls: { visible: false }
     })
   }
 
@@ -68,7 +64,6 @@ export class BaseDesktopNavigation extends React.Component {
       highlightable,
       girlsLinks,
       boysLinks,
-      babyLinks,
       bagCount,
       clickBag,
       clickSearch,
@@ -79,8 +74,7 @@ export class BaseDesktopNavigation extends React.Component {
     } = this.props
     const {
       boys: boysState,
-      girls: girlsState,
-      baby: babyState
+      girls: girlsState
     } = this.state
 
     return (
@@ -139,19 +133,13 @@ export class BaseDesktopNavigation extends React.Component {
                 </li>
                 <li>
                   <HeaderLink
-                    onMouseEnter={this.openDrawer('baby')}
-                    onClick={this.toggleDrawer('baby')}
+                    onMouseEnter={this.closeDrawers}
+                    onFocus={this.closeDrawers}
+                    href='/shop/baby'
                     highlightable={highlightable}
-                    aria-haspopup
                   >
                     Baby
                   </HeaderLink>
-                  <MegaMenu
-                    className='megaMenu'
-                    regions={babyLinks.regions}
-                    renderLink={renderLink}
-                    animationLength={animationLength}
-                    {...babyState} />
                 </li>
                 <li>
                   <HeaderLink
@@ -362,7 +350,6 @@ BaseDesktopNavigation.defaultProps = {
   highlightable: true,
   girlsLinks: girls,
   boysLinks: boys,
-  babyLinks: baby,
   showBlog: REACT_APP_SHOW_BLOG_LINK,
   showSearch: false
 }

--- a/src/modules/header/mobileNavigation/defaultProps.js
+++ b/src/modules/header/mobileNavigation/defaultProps.js
@@ -36,11 +36,6 @@ export const boysLinks = [
   {target: '#', text: 'Vacation-Ready Styles', src: 'https://d2lknnt52h7uhg.cloudfront.net/roa-canon/web/megamenu/NAV_E_Vacation.jpg'}
 ]
 
-export const babyLinks = [
-  {target: '#', text: 'Shop All' },
-  {target: '#', text: 'Starter Kits' }
-]
-
 export const renderLink = (inProps) => {
   const {target, children, ...props } = inProps
   return (<a href={target} {...props}>{children}</a>)

--- a/src/modules/header/mobileNavigation/mobileNavigation.js
+++ b/src/modules/header/mobileNavigation/mobileNavigation.js
@@ -39,7 +39,6 @@ export class BaseMobileNavigation extends React.Component {
     const {
       boysLinks,
       girlsLinks,
-      babyLinks,
       className,
       drawerPosition,
       loggedIn,
@@ -140,26 +139,9 @@ export class BaseMobileNavigation extends React.Component {
                   </Accordion>
                 </li>
                 <li>
-                  <Accordion
-                    toggleElement={
-                      <MobileLinkSecondary>Baby</MobileLinkSecondary>
-                    }>
-                    <UL type='none' leftPad='1rem'>
-                      {
-                        babyLinks && babyLinks.map((link, index) => {
-                          return (
-                            <li key={index}>
-                              <MobileLinkTertiary
-                                target={link.target}
-                                renderLink={renderLink}>
-                                {link.text}
-                              </MobileLinkTertiary>
-                            </li>
-                          )
-                        })
-                      }
-                    </UL>
-                  </Accordion>
+                  <MobileLinkSecondary target='/shop/baby' renderLink={renderLink}>
+                    Baby
+                  </MobileLinkSecondary>
                 </li>
               </UL>
             </li>

--- a/src/modules/header/mobileNavigation/mobileNavigation.md
+++ b/src/modules/header/mobileNavigation/mobileNavigation.md
@@ -8,7 +8,6 @@ _Note: The drawerPosition and position props are only used to constrain the mobi
       position='absolute'
       boysLinks={require('./defaultProps').boysLinks}
       girlsLinks={require('./defaultProps').girlsLinks}
-      babyLinks={require('./defaultProps').babyLinks}
       renderLink={require('./defaultProps').renderLink}
       clickBag={() => console.log('Bag clicked')}
     />
@@ -24,7 +23,6 @@ _Note: The drawerPosition and position props are only used to constrain the mobi
       position='absolute'
       boysLinks={require('./defaultProps').boysLinks}
       girlsLinks={require('./defaultProps').girlsLinks}
-      babyLinks={require('./defaultProps').babyLinks}
       renderLink={require('./defaultProps').renderLink}
       loggedIn />
     <img style={{maxWidth: '100%'}} src='https://www.fillmurray.com/g/500/700' />
@@ -39,7 +37,6 @@ _Note: The drawerPosition and position props are only used to constrain the mobi
     position='absolute'
       boysLinks={require('./defaultProps').boysLinks}
       girlsLinks={require('./defaultProps').girlsLinks}
-      babyLinks={require('./defaultProps').babyLinks}
       renderLink={require('./defaultProps').renderLink}
       isSubscriptionMember
       loggedIn />


### PR DESCRIPTION
#### What does this PR do?
This PR removes the links that were meant to direct to mini starter kits since we have deprioritized them for now.

