### PR TITLE
Update Product Sku in AddToBagState Component When Client-Side Navigating

### DIFF
--- a/src/components/addToBagState/AddToBagState.js
+++ b/src/components/addToBagState/AddToBagState.js
@@ -14,6 +14,21 @@ class AddToBagState extends React.Component {
     this.changeSize = this.changeSize.bind(this)
     this.changeColor = this.changeColor.bind(this)
     this.addToBag = this.addToBag.bind(this)
+    this.findSkuBySize = this.findSkuBySize.bind(this)
+  }
+
+  // When using client-side navigating, we need to update the sku for this
+  // component so we don't duplicate the items already in our cart
+  componentDidUpdate (prevProps) {
+    const { selectedColorway } = this.props
+    const { sizeSelected } = this.state
+    if (selectedColorway !== prevProps.selectedColorway && sizeSelected) {
+      const updatedSku = this.findSkuBySize(selectedColorway, sizeSelected)
+
+      this.setState({
+        sku: updatedSku
+      })
+    }
   }
 
   addToBag () {
@@ -39,15 +54,17 @@ class AddToBagState extends React.Component {
 
   changeSize (size) {
     const { selectedColorway } = this.props
-    const sku = selectedColorway.skus.find(
-      (sku) => sku.size === size
-    )
+    const sku = this.findSkuBySize(selectedColorway, size)
 
     this.setState({
       sizeSelected: size,
       error: null,
       sku
     })
+  }
+
+  findSkuBySize (selectedColorway, size) {
+    return selectedColorway.skus.find(sku => sku.size === size)
   }
 
   changeColor (colorSlug) {

--- a/src/components/addToBagState/AddToBagState.js
+++ b/src/components/addToBagState/AddToBagState.js
@@ -14,19 +14,17 @@ class AddToBagState extends React.Component {
     this.changeSize = this.changeSize.bind(this)
     this.changeColor = this.changeColor.bind(this)
     this.addToBag = this.addToBag.bind(this)
-    this.findSkuBySize = this.findSkuBySize.bind(this)
   }
 
-  // When using client-side navigating, we need to update the sku for this
-  // component so we don't duplicate the items already in our cart
+  // When client-side navigating between different products, we need to reset the 
+  // sku and sizeSelected so they aren't persisted. This was causing a bug where users
+  // were unintentionally duplicating items in their carts
   componentDidUpdate (prevProps) {
     const { selectedColorway } = this.props
-    const { sizeSelected } = this.state
-    if (selectedColorway !== prevProps.selectedColorway && sizeSelected) {
-      const updatedSku = this.findSkuBySize(selectedColorway, sizeSelected)
-
+    if (selectedColorway !== prevProps.selectedColorway) {
       this.setState({
-        sku: updatedSku
+        sku: null,
+        sizeSelected: null
       })
     }
   }
@@ -54,17 +52,13 @@ class AddToBagState extends React.Component {
 
   changeSize (size) {
     const { selectedColorway } = this.props
-    const sku = this.findSkuBySize(selectedColorway, size)
+    const sku = selectedColorway.skus.find(sku => sku.size === size)
 
     this.setState({
       sizeSelected: size,
       error: null,
       sku
     })
-  }
-
-  findSkuBySize (selectedColorway, size) {
-    return selectedColorway.skus.find(sku => sku.size === size)
   }
 
   changeColor (colorSlug) {


### PR DESCRIPTION
#### What does this PR do?
This PR addresses a bug in which clicking "Add to Bag" on PDPs loaded via client-side nagivating would duplicate the last item added to your cart. Because `sizeSelected` and `sku` are treated as internal pieces of state in this component, their old values would persist even when the `selectedColorway` changed. By resetting these state values when `selectedColorway` changes, we ensure that the previous item is not added to their cart again.

#### Relevant Tickets
https://app.shortcut.com/rockets/story/9746/adding-a-recommended-item-to-bag-duplicates-existing-item-in-cart